### PR TITLE
Fix: nef oauth2 inbound auth

### DIFF
--- a/config/nefcfg.yaml
+++ b/config/nefcfg.yaml
@@ -14,8 +14,10 @@ configuration:
   nrfUri: http://127.0.0.10:8000 # A valid URI of NRF
   nrfCertPem: cert/nrf.pem # NRF Certificate
   serviceList: # the SBI services provided by this NEF
-    - serviceName: nnef-pfdmanagement # Nnef_PFDManagement Service
-    - serviceName: nnef-oam # OAM service
+    - serviceName: nnef-pfdmanagement  # Nnef_PFDManagement Service (also mounts /3gpp-pfd-management)
+    - serviceName: nnef-oam            # OAM service
+    - serviceName: 3gpp-traffic-influence # AF-facing Traffic Influence API
+    - serviceName: nnef-callback       # Inbound SMF event notification callback
 
 logger: # log output setting
   enable: true # true or false

--- a/internal/context/nef_context.go
+++ b/internal/context/nef_context.go
@@ -15,6 +15,13 @@ type nef interface {
 	Config() *factory.Config
 }
 
+// NFContext is the interface used by middleware to perform inbound OAuth2 token checks.
+type NFContext interface {
+	AuthorizationCheck(token string, serviceName models.ServiceName) error
+}
+
+var _ NFContext = &NefContext{}
+
 type NefContext struct {
 	nef
 
@@ -158,4 +165,18 @@ func (c *NefContext) GetTokenCtx(serviceName models.ServiceName, targetNF models
 	}
 	return oauth.GetTokenCtx(models.NrfNfManagementNfType_NEF, targetNF,
 		c.nfInstID, c.Config().NrfUri(), string(serviceName))
+}
+
+// AuthorizationCheck validates the inbound OAuth2 bearer token against serviceName.
+// When OAuth2 is disabled it returns nil immediately (pass-through for dev/test).
+func (c *NefContext) AuthorizationCheck(token string, serviceName models.ServiceName) error {
+	if !c.OAuth2Required {
+		logger.CtxLog.Debugf("NefContext::AuthorizationCheck: OAuth2 not required")
+		return nil
+	}
+	logger.CtxLog.Debugf(
+		"NefContext::AuthorizationCheck: tokenPresent[%t] tokenLen[%d] serviceName[%s]",
+		token != "", len(token), serviceName,
+	)
+	return oauth.VerifyOAuth(token, string(serviceName), c.Config().NrfCertPem())
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -17,6 +17,7 @@ var (
 	SBILog       *logrus.Entry
 	ConsumerLog  *logrus.Entry
 	ProcessorLog *logrus.Entry
+	UtilLog      *logrus.Entry
 	TrafInfluLog *logrus.Entry
 	PFDManageLog *logrus.Entry
 	PFDFLog      *logrus.Entry
@@ -48,6 +49,7 @@ func init() {
 	SBILog = NfLog.WithField(logger_util.FieldCategory, "SBI")
 	ConsumerLog = NfLog.WithField(logger_util.FieldCategory, "Consumer")
 	ProcessorLog = NfLog.WithField(logger_util.FieldCategory, "Proc")
+	UtilLog = NfLog.WithField(logger_util.FieldCategory, "Util")
 	TrafInfluLog = NfLog.WithField(logger_util.FieldCategory, "TraffInfl")
 	PFDManageLog = NfLog.WithField(logger_util.FieldCategory, "PFDMng")
 	PFDFLog = NfLog.WithField(logger_util.FieldCategory, "PFDF")

--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -36,7 +36,7 @@ func (p *Processor) SmfNotification(
 	if sub.TiSub != nil {
 		notifDestination = sub.TiSub.NotificationDestination
 	}
-	defer af.Mu.RUnlock()
+	af.Mu.RUnlock()
 
 	if notifDestination == "" {
 		pd := openapi.ProblemDetailsSystemFailure("AF notification destination is empty")

--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -36,7 +36,7 @@ func (p *Processor) SmfNotification(
 	if sub.TiSub != nil {
 		notifDestination = sub.TiSub.NotificationDestination
 	}
-	af.Mu.RUnlock()
+	defer af.Mu.RUnlock()
 
 	if notifDestination == "" {
 		pd := openapi.ProblemDetailsSystemFailure("AF notification destination is empty")

--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -1,6 +1,10 @@
 package processor
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/free5gc/nef/internal/logger"
@@ -8,7 +12,10 @@ import (
 	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/util/metrics/sbi"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/oauth2"
 )
+
+var afCallbackHTTPClient = &http.Client{}
 
 func (p *Processor) SmfNotification(
 	c *gin.Context,
@@ -25,9 +32,100 @@ func (p *Processor) SmfNotification(
 	}
 
 	af.Mu.RLock()
-	defer af.Mu.RUnlock()
+	notifDestination := ""
+	if sub.TiSub != nil {
+		notifDestination = sub.TiSub.NotificationDestination
+	}
+	af.Mu.RUnlock()
 
-	// TODO: Notify AF
+	if notifDestination == "" {
+		pd := openapi.ProblemDetailsSystemFailure("AF notification destination is empty")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(http.StatusInternalServerError, pd)
+		return
+	}
 
-	c.JSON(http.StatusOK, nil)
+	afCallbackTokenCtx, pd, err := p.Context().GetTokenCtx(
+		models.ServiceName("nnef-callback"), models.NrfNfManagementNfType_AF)
+	if err != nil {
+		logger.TrafInfluLog.Errorf("Get token for AF callback failed: %+v", pd)
+		failure := openapi.ProblemDetailsSystemFailure("get token for AF callback failed")
+		if pd != nil && pd.Cause != "" {
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		} else {
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, failure.Cause)
+		}
+		c.JSON(http.StatusBadGateway, failure)
+		return
+	}
+
+	if err := postSmfEventExposureNotificationToAf(notifDestination, eeNotif, afCallbackTokenCtx); err != nil {
+		logger.TrafInfluLog.Errorf("Forward SMF notification to AF failed: %v", err)
+		pd := openapi.ProblemDetailsSystemFailure(err.Error())
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(http.StatusBadGateway, pd)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+func postSmfEventExposureNotificationToAf(
+	notifDestination string,
+	eeNotif *models.NsmfEventExposureNotification,
+	requestCtx context.Context,
+) error {
+	reqBody, err := openapi.Serialize(eeNotif, "application/json")
+	if err != nil {
+		return fmt.Errorf("serialize SMF notification failed: %w", err)
+	}
+	if requestCtx == nil {
+		requestCtx = context.Background()
+	}
+
+	httpReq, err := http.NewRequestWithContext(requestCtx, http.MethodPost, notifDestination, bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("create AF callback request failed: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if err = bindOAuthTokenToRequest(httpReq, requestCtx); err != nil {
+		return fmt.Errorf("bind OAuth2 token for AF callback failed: %w", err)
+	}
+
+	httpRsp, err := afCallbackHTTPClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("send AF callback failed: %w", err)
+	}
+	defer func() {
+		if _, copyErr := io.Copy(io.Discard, httpRsp.Body); copyErr != nil {
+			logger.TrafInfluLog.Warnf("drain AF callback response body failed: %v", copyErr)
+		}
+		if closeErr := httpRsp.Body.Close(); closeErr != nil {
+			logger.TrafInfluLog.Warnf("close AF callback response body failed: %v", closeErr)
+		}
+	}()
+
+	if httpRsp.StatusCode < http.StatusOK || httpRsp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("AF callback returned status code %d", httpRsp.StatusCode)
+	}
+
+	return nil
+}
+
+func bindOAuthTokenToRequest(req *http.Request, requestCtx context.Context) error {
+	if requestCtx == nil {
+		return nil
+	}
+
+	tok, ok := requestCtx.Value(openapi.ContextOAuth2).(oauth2.TokenSource)
+	if !ok {
+		return nil
+	}
+
+	latestToken, err := tok.Token()
+	if err != nil {
+		return err
+	}
+	latestToken.SetAuthHeader(req)
+	return nil
 }

--- a/internal/sbi/processor/callback_test.go
+++ b/internal/sbi/processor/callback_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/free5gc/openapi"
 	"github.com/free5gc/openapi/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
 
@@ -20,7 +23,7 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func TestBindOAuthTokenToRequest(t *testing.T) {
 	t.Run("context without token source", func(t *testing.T) {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", nil)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://af.example.com", nil)
 		if err != nil {
 			t.Fatalf("create request failed: %v", err)
 		}
@@ -94,4 +97,129 @@ func TestPostSmfEventExposureNotificationToAfNon2xx(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when AF callback returns non-2xx")
 	}
+}
+
+// newGinContext returns a fresh gin context backed by a ResponseRecorder.
+func newGinContext() (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	return c, w
+}
+
+// TestSmfNotification_NotifIdNotFound verifies that SmfNotification returns
+// 404 when the NotifId has no matching subscription in NefContext.
+func TestSmfNotification_NotifIdNotFound(t *testing.T) {
+	c, w := newGinContext()
+
+	notif := &models.NsmfEventExposureNotification{NotifId: "unknown-corr-id"}
+	nefApp.Processor().SmfNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestSmfNotification_EmptyNotifDest verifies that SmfNotification returns
+// 500 when the matching subscription has an empty notificationDestination.
+func TestSmfNotification_EmptyNotifDest(t *testing.T) {
+	nefCtx := nefApp.Context()
+	af := nefCtx.NewAf("af-callback-test-1")
+	af.Mu.Lock()
+	correID := nefCtx.NewCorreID()
+	tiSub := &models.NefTrafficInfluSub{
+		NotificationDestination: "", // intentionally empty
+	}
+	afSub := af.NewSub(correID, tiSub)
+	af.Subs[afSub.SubID] = afSub
+	nefCtx.AddAf(af)
+	af.Mu.Unlock()
+	defer func() {
+		nefCtx.DeleteAf(af.AfID)
+		nefCtx.ResetCorreID()
+	}()
+
+	c, w := newGinContext()
+	notif := &models.NsmfEventExposureNotification{NotifId: afSub.NotifCorreID}
+	nefApp.Processor().SmfNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestSmfNotification_SuccessfulForward verifies that SmfNotification forwards
+// the notification to the AF and returns 204 when AF responds successfully.
+func TestSmfNotification_SuccessfulForward(t *testing.T) {
+	originalClient := afCallbackHTTPClient
+	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
+
+	afReceived := false
+	afCallbackHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		afReceived = true
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	nefCtx := nefApp.Context()
+	af := nefCtx.NewAf("af-callback-test-2")
+	af.Mu.Lock()
+	correID := nefCtx.NewCorreID()
+	tiSub := &models.NefTrafficInfluSub{
+		NotificationDestination: "http://af.example.com/notify",
+	}
+	afSub := af.NewSub(correID, tiSub)
+	af.Subs[afSub.SubID] = afSub
+	nefCtx.AddAf(af)
+	af.Mu.Unlock()
+	defer func() {
+		nefCtx.DeleteAf(af.AfID)
+		nefCtx.ResetCorreID()
+	}()
+
+	c, w := newGinContext()
+	notif := &models.NsmfEventExposureNotification{NotifId: afSub.NotifCorreID}
+	nefApp.Processor().SmfNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.True(t, afReceived, "AF mock should have received the notification")
+}
+
+// TestSmfNotification_AfReturnsError verifies that SmfNotification returns
+// 502 (BadGateway) when the AF callback endpoint responds with a non-2xx status.
+func TestSmfNotification_AfReturnsError(t *testing.T) {
+	originalClient := afCallbackHTTPClient
+	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
+
+	afCallbackHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"status":403,"title":"Forbidden"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	nefCtx := nefApp.Context()
+	af := nefCtx.NewAf("af-callback-test-3")
+	af.Mu.Lock()
+	correID := nefCtx.NewCorreID()
+	tiSub := &models.NefTrafficInfluSub{
+		NotificationDestination: "http://af.example.com/notify",
+	}
+	afSub := af.NewSub(correID, tiSub)
+	af.Subs[afSub.SubID] = afSub
+	nefCtx.AddAf(af)
+	af.Mu.Unlock()
+	defer func() {
+		nefCtx.DeleteAf(af.AfID)
+		nefCtx.ResetCorreID()
+	}()
+
+	c, w := newGinContext()
+	notif := &models.NsmfEventExposureNotification{NotifId: afSub.NotifCorreID}
+	nefApp.Processor().SmfNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusBadGateway, w.Code)
 }

--- a/internal/sbi/processor/callback_test.go
+++ b/internal/sbi/processor/callback_test.go
@@ -1,0 +1,97 @@
+package processor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/models"
+	"golang.org/x/oauth2"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestBindOAuthTokenToRequest(t *testing.T) {
+	t.Run("context without token source", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("create request failed: %v", err)
+		}
+
+		err = bindOAuthTokenToRequest(req, context.TODO())
+		if err != nil {
+			t.Fatalf("bind token failed: %v", err)
+		}
+		if got := req.Header.Get("Authorization"); got != "" {
+			t.Fatalf("unexpected authorization header: %q", got)
+		}
+	})
+
+	t.Run("context with token source", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("create request failed: %v", err)
+		}
+
+		tok := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "abc123", TokenType: "Bearer"})
+		tokenCtx := context.WithValue(context.Background(), openapi.ContextOAuth2, tok)
+
+		err = bindOAuthTokenToRequest(req, tokenCtx)
+		if err != nil {
+			t.Fatalf("bind token failed: %v", err)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer abc123" {
+			t.Fatalf("authorization header = %q, want %q", got, "Bearer abc123")
+		}
+	})
+}
+
+func TestPostSmfEventExposureNotificationToAfWithToken(t *testing.T) {
+	originalClient := afCallbackHTTPClient
+	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
+
+	afCallbackHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("Authorization"); got != "Bearer token-for-af" {
+			t.Fatalf("authorization header = %q, want %q", got, "Bearer token-for-af")
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	tok := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token-for-af", TokenType: "Bearer"})
+	tokenCtx := context.WithValue(context.Background(), openapi.ContextOAuth2, tok)
+
+	eeNotif := &models.NsmfEventExposureNotification{NotifId: "notif-1"}
+	if err := postSmfEventExposureNotificationToAf("http://af.example.com/notify", eeNotif, tokenCtx); err != nil {
+		t.Fatalf("post callback failed: %v", err)
+	}
+}
+
+func TestPostSmfEventExposureNotificationToAfNon2xx(t *testing.T) {
+	originalClient := afCallbackHTTPClient
+	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
+
+	afCallbackHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader("forbidden")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	eeNotif := &models.NsmfEventExposureNotification{NotifId: "notif-2"}
+	err := postSmfEventExposureNotificationToAf("http://af.example.com/notify", eeNotif, context.TODO())
+	if err == nil {
+		t.Fatal("expected error when AF callback returns non-2xx")
+	}
+}

--- a/internal/sbi/processor/pfd.go
+++ b/internal/sbi/processor/pfd.go
@@ -67,8 +67,6 @@ func (p *Processor) PostPFDManagementTransactions(
 ) {
 	logger.PFDManageLog.Infof("PostPFDManagementTransactions - scsAsID[%s]", scsAsID)
 
-	// TODO: Authorize the AF
-
 	nefCtx := p.Context()
 	if pd := validatePfdManagement(scsAsID, "-1", pfdMng, nefCtx); pd != nil {
 		if pd.Status == http.StatusInternalServerError {
@@ -233,8 +231,6 @@ func (p *Processor) PutIndividualPFDManagementTransaction(
 ) {
 	logger.PFDManageLog.Infof("PutIndividualPFDManagementTransaction - scsAsID[%s], transID[%s]",
 		scsAsID, transID)
-
-	// TODO: Authorize the AF
 
 	nefCtx := p.Context()
 	if pd := validatePfdManagement(scsAsID, transID, pfdMng, nefCtx); pd != nil {
@@ -502,8 +498,6 @@ func (p *Processor) PutIndividualApplicationPFDManagement(
 	logger.PFDManageLog.Infof("PutIndividualApplicationPFDManagement - scsAsID[%s], transID[%s], appID[%s]",
 		scsAsID, transID, appID)
 
-	// TODO: Authorize the AF
-
 	nefCtx := p.Context()
 	af := nefCtx.GetAf(scsAsID)
 	if af == nil {
@@ -567,8 +561,6 @@ func (p *Processor) PatchIndividualApplicationPFDManagement(
 ) {
 	logger.PFDManageLog.Infof("PatchIndividualApplicationPFDManagement - scsAsID[%s], transID[%s], appID[%s]",
 		scsAsID, transID, appID)
-
-	// TODO: Authorize the AF
 
 	nefCtx := p.Context()
 	af := nefCtx.GetAf(scsAsID)

--- a/internal/sbi/processor/ti.go
+++ b/internal/sbi/processor/ti.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/free5gc/nef/internal/logger"
 	"github.com/free5gc/nef/pkg/factory"
@@ -417,6 +418,17 @@ func (p *Processor) DeleteIndividualTrafficInfluenceSubscription(
 func validateTrafficInfluenceData(
 	tiSub *models.NefTrafficInfluSub,
 ) *models.ProblemDetails {
+	if tiSub.NotificationDestination == "" {
+		pd := openapi.ProblemDetailsMalformedReqSyntax("Missing notificationDestination")
+		return pd
+	}
+
+	parsedNotificationDestination, err := url.ParseRequestURI(tiSub.NotificationDestination)
+	if err != nil || parsedNotificationDestination.Scheme == "" || parsedNotificationDestination.Host == "" {
+		pd := openapi.ProblemDetailsMalformedReqSyntax("Invalid notificationDestination")
+		return pd
+	}
+
 	// TS29.522: One of "afAppId", "trafficFilters" or "ethTrafficFilters" shall be included.
 	if tiSub.AfAppId == "" &&
 		len(tiSub.TrafficFilters) == 0 &&

--- a/internal/sbi/processor/ti_test.go
+++ b/internal/sbi/processor/ti_test.go
@@ -15,9 +15,10 @@ import (
 
 var (
 	tiSub1ForAf1 = models.NefTrafficInfluSub{
-		AfServiceId: "Service1",
-		AfAppId:     "App1",
-		Dnn:         "internet",
+		AfServiceId:             "Service1",
+		AfAppId:                 "App1",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/traffic-influence/app1",
+		Dnn:                     "internet",
 		Snssai: &models.Snssai{
 			Sst: 1,
 			Sd:  "010203",
@@ -43,9 +44,10 @@ var (
 	}
 
 	tiSub2ForAf1 = models.NefTrafficInfluSub{
-		AfServiceId: "Service2",
-		AfAppId:     "App2",
-		Dnn:         "internet",
+		AfServiceId:             "Service2",
+		AfAppId:                 "App2",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/traffic-influence/app2",
+		Dnn:                     "internet",
 		Snssai: &models.Snssai{
 			Sst: 1,
 			Sd:  "010203",
@@ -71,9 +73,10 @@ var (
 	}
 
 	tiSub3ForAf1 = models.NefTrafficInfluSub{
-		AfServiceId: "Service3",
-		AfAppId:     "App3",
-		Dnn:         "internet",
+		AfServiceId:             "Service3",
+		AfAppId:                 "App3",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/traffic-influence/app3",
+		Dnn:                     "internet",
 		Snssai: &models.Snssai{
 			Sst: 1,
 			Sd:  "010203",
@@ -99,8 +102,9 @@ var (
 	}
 
 	tiSub4ForAf1 = models.NefTrafficInfluSub{
-		AfServiceId: "Service4",
-		Dnn:         "internet",
+		AfServiceId:             "Service4",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/traffic-influence/app4",
+		Dnn:                     "internet",
 		Snssai: &models.Snssai{
 			Sst: 1,
 			Sd:  "010203",
@@ -109,8 +113,9 @@ var (
 	}
 
 	tiSub5ForAf1 = models.NefTrafficInfluSub{
-		AfServiceId: "Service5",
-		AfAppId:     "App5",
+		AfServiceId:             "Service5",
+		AfAppId:                 "App5",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/traffic-influence/app5",
 		TrafficFilters: []models.FlowInfo{
 			{
 				FlowId: 1,
@@ -131,23 +136,31 @@ var (
 	}
 
 	tiSub6ForAf1 = models.NefTrafficInfluSub{
-		AfServiceId: "Service6",
-		AfAppId:     "App6",
-		Ipv4Addr:    "10.60.0.11",
+		AfServiceId:             "Service6",
+		AfAppId:                 "App6",
+		AnyUeInd:                true,
+		Dnn:                     "internet",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/traffic-influence/app6",
+		Snssai: &models.Snssai{
+			Sst: 1,
+			Sd:  "010203",
+		},
+		Ipv4Addr: "10.60.0.11",
 		TrafficFilters: []models.FlowInfo{
 			{
 				FlowId: 1,
 				FlowDescriptions: []string{
+					"permit out ip from 192.168.0.26 to 10.60.0.0/16",
 					"permit out ip from 192.168.0.24 to 10.60.0.11",
 				},
 			},
 		},
 	}
-
 	tiSub7ForAf1 = models.NefTrafficInfluSub{
-		AfServiceId: "Service7",
-		AfAppId:     "App7",
-		Ipv4Addr:    "10.60.0.12",
+		AfServiceId:             "Service7",
+		AfAppId:                 "App7",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/traffic-influence/app7",
+		Ipv4Addr:                "10.60.0.12",
 		TrafficFilters: []models.FlowInfo{
 			{
 				FlowId: 1,
@@ -158,6 +171,29 @@ var (
 		},
 		TrafficRoutes: []*models.RouteToLocation{
 			nil,
+		},
+	}
+	tiSub8ForAf1 = models.NefTrafficInfluSub{
+		AfServiceId: "Service8",
+		AfAppId:     "App8",
+		Dnn:         "internet",
+		Snssai: &models.Snssai{
+			Sst: 1,
+			Sd:  "010203",
+		},
+		AnyUeInd: true,
+		TrafficFilters: []models.FlowInfo{
+			{
+				FlowId: 1,
+				FlowDescriptions: []string{
+					"permit out ip from 192.168.0.21 to 10.60.0.0/16",
+				},
+			},
+		},
+		TrafficRoutes: []*models.RouteToLocation{
+			{
+				Dnai: "mec",
+			},
 		},
 	}
 
@@ -353,7 +389,20 @@ func TestPostTrafficInfluenceSubscription(t *testing.T) {
 			},
 		},
 		{
-			description: "TC3: Missing one of afAppId, trafficFilters or ethTrafficFilters",
+			description: "TC3: Missing notificationDestination",
+			afID:        "af1",
+			tiSub:       &tiSub8ForAf1,
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusBadRequest,
+				Body: &models.ProblemDetails{
+					Status: http.StatusBadRequest,
+					Title:  "Malformed request syntax",
+					Detail: "Missing notificationDestination",
+				},
+			},
+		},
+		{
+			description: "TC4: Missing one of afAppId, trafficFilters or ethTrafficFilters",
 			afID:        "af1",
 			tiSub:       &tiSub4ForAf1,
 			expectedResponse: &HandlerResponse{
@@ -366,7 +415,7 @@ func TestPostTrafficInfluenceSubscription(t *testing.T) {
 			},
 		},
 		{
-			description: "TC4: Missing one of Gpsi, Ipv4Addr, Ipv6Addr, ExternalGroupId, AnyUeInd",
+			description: "TC5: Missing one of Gpsi, Ipv4Addr, Ipv6Addr, ExternalGroupId, AnyUeInd",
 			afID:        "af1",
 			tiSub:       &tiSub5ForAf1,
 			expectedResponse: &HandlerResponse{
@@ -645,7 +694,21 @@ func TestPutIndividualTrafficInfluenceSubscription(t *testing.T) {
 			},
 		},
 		{
-			description: "TC4: Missing one of afAppId, trafficFilters or ethTrafficFilters",
+			description: "TC4: Missing notificationDestination",
+			afID:        "af1",
+			subID:       "1",
+			tiSub:       &tiSub8ForAf1,
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusBadRequest,
+				Body: &models.ProblemDetails{
+					Status: http.StatusBadRequest,
+					Title:  "Malformed request syntax",
+					Detail: "Missing notificationDestination",
+				},
+			},
+		},
+		{
+			description: "TC5: Missing one of afAppId, trafficFilters or ethTrafficFilters",
 			afID:        "af1",
 			subID:       "4",
 			tiSub:       &tiSub4ForAf1,
@@ -659,7 +722,7 @@ func TestPutIndividualTrafficInfluenceSubscription(t *testing.T) {
 			},
 		},
 		{
-			description: "TC5: Missing one of Gpsi, Ipv4Addr, Ipv6Addr, ExternalGroupId, AnyUeInd",
+			description: "TC6: Missing one of Gpsi, Ipv4Addr, Ipv6Addr, ExternalGroupId, AnyUeInd",
 			afID:        "af1",
 			subID:       "5",
 			tiSub:       &tiSub5ForAf1,

--- a/internal/sbi/server.go
+++ b/internal/sbi/server.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/free5gc/nef/internal/logger"
 	"github.com/free5gc/nef/internal/sbi/processor"
+	nef_util "github.com/free5gc/nef/internal/util"
 	"github.com/free5gc/nef/pkg/app"
 	"github.com/free5gc/nef/pkg/factory"
+	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/util/httpwrapper"
 	logger_util "github.com/free5gc/util/logger"
 	"github.com/free5gc/util/metrics"
@@ -45,25 +47,55 @@ func NewServer(nef nef, tlsKeyLogPath string) (*Server, error) {
 
 	s.router.Use(metrics.InboundMetrics())
 
-	endpoints := s.getTrafficInfluenceRoutes()
-	group := s.router.Group(factory.TraffInfluResUriPrefix)
-	applyRoutes(group, endpoints)
+	// Callback endpoint: protected by OAuth2 middleware (callers must present
+	// a valid nnef-callback Bearer token issued by NRF).
+	callbackAuthCheck := nef_util.NewRouterAuthorizationCheck(models.ServiceName("nnef-callback"))
+	callbackGroup := s.router.Group(factory.NefCallbackResUriPrefix)
+	callbackGroup.Use(func(c *gin.Context) {
+		callbackAuthCheck.Check(c, s.Context())
+	})
+	applyRoutes(callbackGroup, s.getCallbackRoutes())
 
-	endpoints = s.getPFDManagementRoutes()
-	group = s.router.Group(factory.PfdMngResUriPrefix)
-	applyRoutes(group, endpoints)
+	// All other route groups are mounted only when their service is declared in
+	// ServiceList, and each group is protected by OAuth2 middleware.
+	for _, service := range s.Config().ServiceList() {
+		switch service.ServiceName {
+		case factory.ServiceNefPfd:
+			// nnef-pfdmanagement covers both the external AF-facing API
+			// (/3gpp-pfd-management) and the SBI PFDF API (/nnef-pfdmanagement).
+			authCheck := nef_util.NewRouterAuthorizationCheck(models.ServiceName_NNEF_PFDMANAGEMENT)
 
-	endpoints = s.getPFDFRoutes()
-	group = s.router.Group(factory.NefPfdMngResUriPrefix)
-	applyRoutes(group, endpoints)
+			pfdMngGroup := s.router.Group(factory.PfdMngResUriPrefix)
+			pfdMngGroup.Use(func(c *gin.Context) {
+				authCheck.Check(c, s.Context())
+			})
+			applyRoutes(pfdMngGroup, s.getPFDManagementRoutes())
 
-	endpoints = s.getOamRoutes()
-	group = s.router.Group(factory.NefOamResUriPrefix)
-	applyRoutes(group, endpoints)
+			pfdFGroup := s.router.Group(factory.NefPfdMngResUriPrefix)
+			pfdFGroup.Use(func(c *gin.Context) {
+				authCheck.Check(c, s.Context())
+			})
+			applyRoutes(pfdFGroup, s.getPFDFRoutes())
 
-	endpoints = s.getCallbackRoutes()
-	group = s.router.Group(factory.NefCallbackResUriPrefix)
-	applyRoutes(group, endpoints)
+		case factory.ServiceNefOam:
+			authCheck := nef_util.NewRouterAuthorizationCheck(models.ServiceName(factory.ServiceNefOam))
+
+			oamGroup := s.router.Group(factory.NefOamResUriPrefix)
+			oamGroup.Use(func(c *gin.Context) {
+				authCheck.Check(c, s.Context())
+			})
+			applyRoutes(oamGroup, s.getOamRoutes())
+
+		case factory.ServiceTraffInflu:
+			// 3gpp-traffic-influence is an AF-facing API (3GPP TS 29.522);
+			authCheck := nef_util.NewRouterAuthorizationCheck(models.ServiceName_3GPP_TRAFFIC_INFLUENCE)
+			tiGroup := s.router.Group(factory.TraffInfluResUriPrefix)
+			tiGroup.Use(func(c *gin.Context) {
+				authCheck.Check(c, s.Context())
+			})
+			applyRoutes(tiGroup, s.getTrafficInfluenceRoutes())
+		}
+	}
 
 	s.router.Use(cors.New(cors.Config{
 		AllowMethods: []string{"GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"},

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,36 @@
 package util
 
+import (
+	"net/http"
+
+	nef_context "github.com/free5gc/nef/internal/context"
+	"github.com/free5gc/nef/internal/logger"
+	"github.com/free5gc/openapi/models"
+	"github.com/gin-gonic/gin"
+)
+
 // Metrics consts
 const (
 	METRICS_APP_PFDS_CREATION_ERR_MSG = "PFDs for all application were not created successfully"
 )
+
+type RouterAuthorizationCheck struct {
+	serviceName models.ServiceName
+}
+
+func NewRouterAuthorizationCheck(serviceName models.ServiceName) *RouterAuthorizationCheck {
+	return &RouterAuthorizationCheck{
+		serviceName: serviceName,
+	}
+}
+
+func (rac *RouterAuthorizationCheck) Check(c *gin.Context, nefCtx nef_context.NFContext) {
+	token := c.Request.Header.Get("Authorization")
+	if err := nefCtx.AuthorizationCheck(token, rac.serviceName); err != nil {
+		logger.UtilLog.Debugf("RouterAuthorizationCheck::Check Unauthorized: %s", err.Error())
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		c.Abort()
+		return
+	}
+	logger.UtilLog.Debugf("RouterAuthorizationCheck::Check Authorized")
+}

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -127,9 +127,14 @@ func (c *Configuration) validate() (bool, error) {
 		switch s.ServiceName {
 		case ServiceNefPfd:
 		case ServiceNefOam:
+		case ServiceTraffInflu:
+		case ServiceNefCallback:
 		default:
-			err := errors.New("invalid serviceList[" + strconv.Itoa(i) + "]: " +
-				s.ServiceName + ", should be " + ServiceNefPfd + " or " + ServiceNefOam)
+			err := errors.New(
+				"invalid serviceList[" + strconv.Itoa(i) + "]: " +
+					s.ServiceName + ", should be " + ServiceNefPfd + ", " +
+					ServiceNefOam + ", " + ServiceTraffInflu + ", or " + ServiceNefCallback,
+			)
 			return false, appendInvalid(err)
 		}
 	}


### PR DESCRIPTION
- Add NFContext interface and AuthorizationCheck method to NefContext, calling oauth.VerifyOAuth for inbound token validation
- Add RouterAuthorizationCheck utility (util/util.go) and UtilLog
- Refactor server.go: mount routes conditionally per ServiceList entry and attach per-group OAuth2 middleware
- Extend ServiceList validation in config.go to include 3gpp-traffic-influence
- Add 3gpp-traffic-influence to default serviceList in nefcfg.yaml
- Remove four stale '// TODO: Authorize the AF' comments from pfd.go now that middleware handles authorization

Fixes: free5gc/free5gc#858 、 free5gc/free5gc#859 、 free5gc/free5gc#860 、 free5gc/free5gc#861 、 free5gc/free5gc#862