### PR TITLE
feat(nef): add Monitoring Event API (3GPP TS 29.122)

### DIFF
--- a/config/nefcfg.yaml
+++ b/config/nefcfg.yaml
@@ -17,7 +17,8 @@ configuration:
     - serviceName: nnef-pfdmanagement  # Nnef_PFDManagement Service (also mounts /3gpp-pfd-management)
     - serviceName: nnef-oam            # OAM service
     - serviceName: 3gpp-traffic-influence # AF-facing Traffic Influence API
-    - serviceName: nnef-callback       # Inbound SMF event notification callback
+    - serviceName: 3gpp-monitoring-event  # AF-facing Monitoring Event API
+    - serviceName: nnef-callback       # Inbound SMF/AMF event notification callback
 
 logger: # log output setting
   enable: true # true or false

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/free5gc/nef
 
 go 1.26.2
 
+// TEMPORARY: points at the companion openapi PR (free5gc/openapi#82) branch,
+// rebased onto v1.3.0, which adds the Monitoring Event models this PR needs.
+// Remove this replace directive once that PR merges and a new free5gc/openapi
+// release/tag incorporating it is available, then bump the require below to match.
+replace github.com/free5gc/openapi => /Users/dev/dev/openapi-ref
+
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.26.2
 // rebased onto v1.3.0, which adds the Monitoring Event models this PR needs.
 // Remove this replace directive once that PR merges and a new free5gc/openapi
 // release/tag incorporating it is available, then bump the require below to match.
-replace github.com/free5gc/openapi => /Users/dev/dev/openapi-ref
+replace github.com/free5gc/openapi => github.com/ALIIQBAL786/openapi v1.2.5-0.20260821073625-0370cb189670
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/free5gc/nas v1.2.4-0.20260707083822-348faf940c55 h1:II2TnEwOTj6z+Iiq+
 github.com/free5gc/nas v1.2.4-0.20260707083822-348faf940c55/go.mod h1:T/krdGjxSut+MQJAFFBS4lsWZa/NPEz7wO0G/D3qHeE=
 github.com/free5gc/ngap v1.1.4-0.20260707055048-c26215fe47ef h1:+TrPHbLcROsjDUuwsMBQTAi7SeKMP2o0v7xjsTJEJ8s=
 github.com/free5gc/ngap v1.1.4-0.20260707055048-c26215fe47ef/go.mod h1:1lfw7JP0fs8bdv0B685KDC2/shOciL9gf1f3KwKnGvk=
-github.com/free5gc/openapi v1.3.0 h1:dVJ9FXM2qr8jesiHeTR9ZGZwYRmr7qcHx5Xgm/ip6s0=
-github.com/free5gc/openapi v1.3.0/go.mod h1:ggzAcwqg4JotSSdUvFFFruK6M0Yyr6mhBOCFaDHZmdE=
 github.com/free5gc/util v1.4.0 h1:vdjzRUgxEYtjIy6AYkO4JuIQHV8DqBb1paNqJiajeus=
 github.com/free5gc/util v1.4.0/go.mod h1:ihddsLLECOOIkYzAlgkK3CVXmQh9HTGEagaJT9Rv/+I=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ALIIQBAL786/openapi v1.2.5-0.20260821073625-0370cb189670 h1:HPDjFpSWWlNZICKhSbI2XzXf8hDwe+9mdHhfuOTPtP4=
+github.com/ALIIQBAL786/openapi v1.2.5-0.20260821073625-0370cb189670/go.mod h1:ggzAcwqg4JotSSdUvFFFruK6M0Yyr6mhBOCFaDHZmdE=
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4aoV2Iu8bR55nU6iKMVfYVLjY=
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=

--- a/internal/context/af_context.go
+++ b/internal/context/af_context.go
@@ -11,13 +11,15 @@ import (
 )
 
 type AfData struct {
-	AfID       string
-	NumSubscID uint64
-	NumTransID uint64
-	Subs       map[string]*AfSubscription
-	PfdTrans   map[string]*AfPfdTransaction
-	Mu         sync.RWMutex
-	Log        *logrus.Entry
+	AfID          string
+	NumSubscID    uint64
+	NumTransID    uint64
+	NumMonSubscID uint64
+	Subs          map[string]*AfSubscription
+	PfdTrans      map[string]*AfPfdTransaction
+	MonSubs       map[string]*AfMonitoringSubscription
+	Mu            sync.RWMutex
+	Log           *logrus.Entry
 }
 
 func (a *AfData) NewSub(numCorreID uint64, tiSub *models.Nef_TrafInfl_TrafficInfluSub) *AfSubscription {
@@ -29,6 +31,20 @@ func (a *AfData) NewSub(numCorreID uint64, tiSub *models.Nef_TrafInfl_TrafficInf
 		Log:          a.Log.WithField(logger.FieldSubID, fmt.Sprintf("SUB:%d", a.NumSubscID)),
 	}
 	sub.Log.Infoln("New subscription")
+	return &sub
+}
+
+func (a *AfData) NewMonSub(
+	numCorreID uint64, monSub *models.NefMonitoringEventSubscription,
+) *AfMonitoringSubscription {
+	a.NumMonSubscID++
+	sub := AfMonitoringSubscription{
+		NotifCorreID: strconv.FormatUint(numCorreID, 10),
+		SubID:        strconv.FormatUint(a.NumMonSubscID, 10),
+		MonSub:       monSub,
+		Log:          a.Log.WithField(logger.FieldSubID, fmt.Sprintf("MONSUB:%d", a.NumMonSubscID)),
+	}
+	sub.Log.Infoln("New monitoring event subscription")
 	return &sub
 }
 

--- a/internal/context/af_monitoring_subscription.go
+++ b/internal/context/af_monitoring_subscription.go
@@ -1,0 +1,14 @@
+package context
+
+import (
+	"github.com/free5gc/openapi/models"
+	"github.com/sirupsen/logrus"
+)
+
+type AfMonitoringSubscription struct {
+	SubID        string
+	MonSub       *models.NefMonitoringEventSubscription
+	AmfSubID     string // AMF-side (Namf_EventExposure) subscription resource ID, needed to delete it
+	NotifCorreID string
+	Log          *logrus.Entry
+}

--- a/internal/context/nef_context.go
+++ b/internal/context/nef_context.go
@@ -28,6 +28,8 @@ type NefContext struct {
 	nfInstID       string // NF Instance ID
 	pcfPaUri       string
 	udrDrUri       string
+	namfEvtsUri    string
+	udmSdmUri      string
 	numCorreID     uint64
 	OAuth2Required bool
 	afs            map[string]*AfData
@@ -83,11 +85,38 @@ func (c *NefContext) SetUdrDrUri(uri string) {
 	logger.CtxLog.Infof("Set udrDrUri: [%s]", c.udrDrUri)
 }
 
+func (c *NefContext) NamfEvtsUri() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.namfEvtsUri
+}
+
+func (c *NefContext) SetNamfEvtsUri(uri string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.namfEvtsUri = uri
+	logger.CtxLog.Infof("Set namfEvtsUri: [%s]", c.namfEvtsUri)
+}
+
+func (c *NefContext) UdmSdmUri() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.udmSdmUri
+}
+
+func (c *NefContext) SetUdmSdmUri(uri string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.udmSdmUri = uri
+	logger.CtxLog.Infof("Set udmSdmUri: [%s]", c.udmSdmUri)
+}
+
 func (c *NefContext) NewAf(afID string) *AfData {
 	af := &AfData{
 		AfID:     afID,
 		Subs:     make(map[string]*AfSubscription),
 		PfdTrans: make(map[string]*AfPfdTransaction),
+		MonSubs:  make(map[string]*AfMonitoringSubscription),
 		Log:      logger.CtxLog.WithField(logger.FieldAFID, fmt.Sprintf("AF:%s", afID)),
 	}
 	return af
@@ -147,6 +176,22 @@ func (c *NefContext) FindAfSub(CorrID string) (*AfData, *AfSubscription) {
 	for _, af := range c.afs {
 		af.Mu.RLock()
 		for _, sub := range af.Subs {
+			if sub.NotifCorreID == CorrID {
+				defer af.Mu.RUnlock()
+				return af, sub
+			}
+		}
+		af.Mu.RUnlock()
+	}
+	return nil, nil
+}
+
+func (c *NefContext) FindAfMonSub(CorrID string) (*AfData, *AfMonitoringSubscription) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, af := range c.afs {
+		af.Mu.RLock()
+		for _, sub := range af.MonSubs {
 			if sub.NotifCorreID == CorrID {
 				defer af.Mu.RUnlock()
 				return af, sub

--- a/internal/sbi/api_callback.go
+++ b/internal/sbi/api_callback.go
@@ -17,6 +17,11 @@ func (s *Server) getCallbackRoutes() []Route {
 			Pattern: "/notification/smf",
 			APIFunc: s.apiPostSmfNotification,
 		},
+		{
+			Method:  http.MethodPost,
+			Pattern: "/notification/amf-event",
+			APIFunc: s.apiPostAmfEventNotification,
+		},
 	}
 }
 
@@ -41,4 +46,27 @@ func (s *Server) apiPostSmfNotification(gc *gin.Context) {
 	}
 
 	s.Processor().SmfNotification(gc, &eeNotif)
+}
+
+func (s *Server) apiPostAmfEventNotification(gc *gin.Context) {
+	var notif models.Amf_EvtExpos_AmfEventNotification
+	reqBody, err := gc.GetRawData()
+	if err != nil {
+		logger.SBILog.Errorf("Get Request Body error: %+v", err)
+		pd := openapi.ProblemDetailsSystemFailure(err.Error())
+		gc.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		gc.JSON(http.StatusInternalServerError, pd)
+		return
+	}
+
+	err = openapi.Deserialize(&notif, reqBody, "application/json")
+	if err != nil {
+		logger.SBILog.Errorf("Deserialize Request Body error: %+v", err)
+		pd := openapi.ProblemDetailsMalformedReqSyntax(err.Error())
+		gc.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		gc.JSON(http.StatusBadRequest, pd)
+		return
+	}
+
+	s.Processor().AmfEventNotification(gc, &notif)
 }

--- a/internal/sbi/api_monitoring.go
+++ b/internal/sbi/api_monitoring.go
@@ -1,0 +1,73 @@
+package sbi
+
+import (
+	"net/http"
+
+	"github.com/free5gc/nef/internal/logger"
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/util/metrics/sbi"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) getMonitoringEventRoutes() []Route {
+	return []Route{
+		{
+			Method:  http.MethodGet,
+			Pattern: "/:afID/subscriptions",
+			APIFunc: s.apiGetMonitoringEventSubscriptions,
+		},
+		{
+			Method:  http.MethodPost,
+			Pattern: "/:afID/subscriptions",
+			APIFunc: s.apiPostMonitoringEventSubscription,
+		},
+		{
+			Method:  http.MethodGet,
+			Pattern: "/:afID/subscriptions/:subID",
+			APIFunc: s.apiGetIndividualMonitoringEventSubscription,
+		},
+		{
+			Method:  http.MethodDelete,
+			Pattern: "/:afID/subscriptions/:subID",
+			APIFunc: s.apiDeleteIndividualMonitoringEventSubscription,
+		},
+	}
+}
+
+func (s *Server) apiGetMonitoringEventSubscriptions(gc *gin.Context) {
+	s.Processor().GetMonitoringEventSubscriptions(gc, gc.Param("afID"))
+}
+
+func (s *Server) apiPostMonitoringEventSubscription(gc *gin.Context) {
+	var monSub models.NefMonitoringEventSubscription
+	reqBody, err := gc.GetRawData()
+	if err != nil {
+		logger.SBILog.Errorf("Get Request Body error: %+v", err)
+		pd := openapi.ProblemDetailsSystemFailure(err.Error())
+		gc.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		gc.JSON(http.StatusInternalServerError, pd)
+		return
+	}
+
+	err = openapi.Deserialize(&monSub, reqBody, "application/json")
+	if err != nil {
+		logger.SBILog.Errorf("Deserialize Request Body error: %+v", err)
+		pd := openapi.ProblemDetailsMalformedReqSyntax(err.Error())
+		gc.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		gc.JSON(http.StatusBadRequest, pd)
+		return
+	}
+
+	s.Processor().PostMonitoringEventSubscription(gc, gc.Param("afID"), &monSub)
+}
+
+func (s *Server) apiGetIndividualMonitoringEventSubscription(gc *gin.Context) {
+	s.Processor().GetIndividualMonitoringEventSubscription(
+		gc, gc.Param("afID"), gc.Param("subID"))
+}
+
+func (s *Server) apiDeleteIndividualMonitoringEventSubscription(gc *gin.Context) {
+	s.Processor().DeleteIndividualMonitoringEventSubscription(
+		gc, gc.Param("afID"), gc.Param("subID"))
+}

--- a/internal/sbi/consumer/amf_service.go
+++ b/internal/sbi/consumer/amf_service.go
@@ -1,0 +1,178 @@
+package consumer
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/free5gc/nef/internal/logger"
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/amf/EvtExpos"
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/openapi/nrf/NFDisc"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
+)
+
+type namfService struct {
+	consumer *Consumer
+
+	mu      sync.RWMutex
+	clients map[string]*EvtExpos.APIClient
+}
+
+func (s *namfService) getEventExposureClient(uri string) *EvtExpos.APIClient {
+	if uri == "" {
+		return nil
+	}
+
+	s.mu.RLock()
+	if client, ok := s.clients[uri]; ok {
+		defer s.mu.RUnlock()
+		return client
+	}
+	s.mu.RUnlock()
+
+	configuration := EvtExpos.NewConfiguration()
+	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
+	configuration.SetHTTPClient(http.DefaultClient)
+	cli := EvtExpos.NewAPIClient(configuration)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clients[uri] = cli
+	return cli
+}
+
+func (s *namfService) getNamfEvtsUri() (string, error) {
+	uri := s.consumer.Context().NamfEvtsUri()
+	if uri == "" {
+		localVarOptionals := NFDisc.SearchNFInstancesRequest{
+			ServiceNames: []models.Nrf_NFMgmt_ServiceName{
+				models.Nrf_NFMgmt_ServiceName_NAMF_EVTS,
+			},
+		}
+		_, sUri, err := s.consumer.SearchNFInstances(
+			s.consumer.Config().NrfUri(),
+			models.Nrf_NFMgmt_ServiceName_NAMF_EVTS,
+			models.Nrf_NFMgmt_NFType_AMF,
+			models.Nrf_NFMgmt_NFType_NEF,
+			&localVarOptionals,
+		)
+		if err == nil {
+			s.consumer.Context().SetNamfEvtsUri(sUri)
+		}
+		return sUri, err
+	}
+	return uri, nil
+}
+
+// CreateEventSubscription creates a Namf_EventExposure subscription on behalf of an AF's
+// monitoring event subscription. AMF's CreateAMFEventSubscriptionProcedure looks up the
+// target UE by Supi only (it does not resolve Gpsi), so the caller must already have
+// translated the AF-facing GPSI to a SUPI (see nudmService.GetSupiFromGpsi).
+// 3GPP TS 29.518 Release 17
+func (s *namfService) CreateEventSubscription(
+	supi string,
+	events []models.Amf_EvtExpos_AmfEventType,
+	notifyUri, correlationID string,
+) (amfSubID string, pd *models.ProblemDetails, err error) {
+	uri, err := s.getNamfEvtsUri()
+	if err != nil {
+		return "", nil, err
+	}
+
+	client := s.getEventExposureClient(uri)
+	if client == nil {
+		return "", nil, openapi.ReportError("could not initialize the EventExposure client")
+	}
+
+	ctx, _, err := s.consumer.Context().GetTokenCtx(
+		models.Nrf_NFMgmt_ServiceName_NAMF_EVTS, models.Nrf_NFMgmt_NFType_AMF)
+	if err != nil {
+		return "", nil, err
+	}
+
+	eventList := make([]models.Amf_EvtExpos_AmfEvent, 0, len(events))
+	for _, evtType := range events {
+		eventList = append(eventList, models.Amf_EvtExpos_AmfEvent{Type: evtType})
+	}
+
+	createReq := &EvtExpos.CreateSubscriptionRequest{
+		RequestBody: &models.Amf_EvtExpos_AmfCreateEventSubscription{
+			Subscription: &models.Amf_EvtExpos_AmfEventSubscription{
+				EventList:           eventList,
+				EventNotifyUri:      notifyUri,
+				NotifyCorrelationId: correlationID,
+				Supi:                supi,
+			},
+		},
+	}
+
+	rsp, errCreateSub := client.SubscriptionsCollectionCollectionApi.CreateSubscription(ctx, createReq)
+	if errCreateSub != nil {
+		switch apiErr := errCreateSub.(type) {
+		case openapi.GenericOpenAPIError:
+			switch errorModel := apiErr.Model().(type) {
+			case EvtExpos.CreateSubscriptionError:
+				return "", errorModel.ProblemDetails, nil
+			case error:
+				return "", openapi.ProblemDetailsSystemFailure(errorModel.Error()), nil
+			default:
+				return "", nil, openapi.ReportError("openapi error")
+			}
+		case error:
+			return "", openapi.ProblemDetailsSystemFailure(apiErr.Error()), nil
+		default:
+			return "", nil, openapi.ReportError("server no response")
+		}
+	}
+
+	logger.ConsumerLog.Debugf("CreateEventSubscription RspData: %+v", rsp.Amf_EvtExpos_AmfCreatedEventSubscription)
+	return rsp.Amf_EvtExpos_AmfCreatedEventSubscription.SubscriptionId, nil, nil
+}
+
+// DeleteEventSubscription deletes a Namf_EventExposure subscription previously created via
+// CreateEventSubscription.
+// 3GPP TS 29.518 Release 17
+func (s *namfService) DeleteEventSubscription(amfSubID string) (*models.ProblemDetails, error) {
+	uri, err := s.getNamfEvtsUri()
+	if err != nil {
+		return nil, err
+	}
+
+	client := s.getEventExposureClient(uri)
+	if client == nil {
+		return nil, openapi.ReportError("could not initialize the EventExposure client")
+	}
+
+	ctx, _, err := s.consumer.Context().GetTokenCtx(
+		models.Nrf_NFMgmt_ServiceName_NAMF_EVTS, models.Nrf_NFMgmt_NFType_AMF)
+	if err != nil {
+		return nil, err
+	}
+
+	deleteReq := &EvtExpos.DeleteSubscriptionRequest{
+		SubscriptionId: &amfSubID,
+	}
+
+	_, errDeleteSub := client.IndividualSubscriptionDocumentApi.DeleteSubscription(ctx, deleteReq)
+	if errDeleteSub != nil {
+		switch apiErr := errDeleteSub.(type) {
+		case openapi.GenericOpenAPIError:
+			switch errorModel := apiErr.Model().(type) {
+			case EvtExpos.DeleteSubscriptionError:
+				return errorModel.ProblemDetails, nil
+			case error:
+				return openapi.ProblemDetailsSystemFailure(errorModel.Error()), nil
+			default:
+				return nil, openapi.ReportError("openapi error")
+			}
+		case error:
+			return openapi.ProblemDetailsSystemFailure(apiErr.Error()), nil
+		default:
+			return nil, openapi.ReportError("server no response")
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/sbi/consumer/consumer.go
+++ b/internal/sbi/consumer/consumer.go
@@ -4,9 +4,11 @@ import (
 	"github.com/free5gc/nef/internal/logger"
 	"github.com/free5gc/nef/pkg/app"
 	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/amf/EvtExpos"
 	"github.com/free5gc/openapi/nrf/NFDisc"
 	"github.com/free5gc/openapi/nrf/NFMgmt"
 	"github.com/free5gc/openapi/pcf/PolAuth"
+	"github.com/free5gc/openapi/udm/SDM"
 	"github.com/free5gc/openapi/udr/DR"
 )
 
@@ -21,6 +23,8 @@ type Consumer struct {
 	*nnrfService
 	*npcfService
 	*nudrService
+	*namfService
+	*nudmService
 }
 
 func NewConsumer(nef nef) (*Consumer, error) {
@@ -42,6 +46,16 @@ func NewConsumer(nef nef) (*Consumer, error) {
 	c.nudrService = &nudrService{
 		consumer: c,
 		clients:  make(map[string]*DR.APIClient),
+	}
+
+	c.namfService = &namfService{
+		consumer: c,
+		clients:  make(map[string]*EvtExpos.APIClient),
+	}
+
+	c.nudmService = &nudmService{
+		consumer: c,
+		clients:  make(map[string]*SDM.APIClient),
 	}
 	return c, nil
 }

--- a/internal/sbi/consumer/udm_service.go
+++ b/internal/sbi/consumer/udm_service.go
@@ -1,0 +1,117 @@
+package consumer
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/free5gc/nef/internal/logger"
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/openapi/nrf/NFDisc"
+	"github.com/free5gc/openapi/udm/SDM"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
+)
+
+type nudmService struct {
+	consumer *Consumer
+
+	mu      sync.RWMutex
+	clients map[string]*SDM.APIClient
+}
+
+func (s *nudmService) getSdmClient(uri string) *SDM.APIClient {
+	if uri == "" {
+		return nil
+	}
+
+	s.mu.RLock()
+	if client, ok := s.clients[uri]; ok {
+		defer s.mu.RUnlock()
+		return client
+	}
+	s.mu.RUnlock()
+
+	configuration := SDM.NewConfiguration()
+	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
+	configuration.SetHTTPClient(http.DefaultClient)
+	cli := SDM.NewAPIClient(configuration)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clients[uri] = cli
+	return cli
+}
+
+func (s *nudmService) getUdmSdmUri() (string, error) {
+	uri := s.consumer.Context().UdmSdmUri()
+	if uri == "" {
+		localVarOptionals := NFDisc.SearchNFInstancesRequest{
+			ServiceNames: []models.Nrf_NFMgmt_ServiceName{
+				models.Nrf_NFMgmt_ServiceName_NUDM_SDM,
+			},
+		}
+		_, sUri, err := s.consumer.SearchNFInstances(
+			s.consumer.Config().NrfUri(),
+			models.Nrf_NFMgmt_ServiceName_NUDM_SDM,
+			models.Nrf_NFMgmt_NFType_UDM,
+			models.Nrf_NFMgmt_NFType_NEF,
+			&localVarOptionals,
+		)
+		if err == nil {
+			s.consumer.Context().SetUdmSdmUri(sUri)
+		}
+		return sUri, err
+	}
+	return uri, nil
+}
+
+// GetSupiFromGpsi resolves an AF-facing GPSI (external ID/MSISDN) to the SUPI AMF's
+// Namf_EventExposure subscription actually requires, via Nudm_SDM's GPSI-to-SUPI
+// translation (3GPP TS 29.503 clause 5.2.2.7.1), which itself queries UDR.
+func (s *nudmService) GetSupiFromGpsi(gpsi string) (supi string, pd *models.ProblemDetails, err error) {
+	uri, err := s.getUdmSdmUri()
+	if err != nil {
+		return "", nil, err
+	}
+
+	client := s.getSdmClient(uri)
+	if client == nil {
+		return "", nil, openapi.ReportError("could not initialize the SubscriberDataManagement client")
+	}
+
+	ctx, _, err := s.consumer.Context().GetTokenCtx(
+		models.Nrf_NFMgmt_ServiceName_NUDM_SDM, models.Nrf_NFMgmt_NFType_UDM)
+	if err != nil {
+		return "", nil, err
+	}
+
+	req := &SDM.GetSupiOrGpsiRequest{
+		UeId: &gpsi,
+	}
+
+	rsp, errGetSupiOrGpsi := client.GPSIToSUPITranslationOrSUPIToGPSITranslationApi.GetSupiOrGpsi(ctx, req)
+	if errGetSupiOrGpsi != nil {
+		switch apiErr := errGetSupiOrGpsi.(type) {
+		case openapi.GenericOpenAPIError:
+			switch errorModel := apiErr.Model().(type) {
+			case SDM.GetSupiOrGpsiError:
+				return "", errorModel.ProblemDetails, nil
+			case error:
+				return "", openapi.ProblemDetailsSystemFailure(errorModel.Error()), nil
+			default:
+				return "", nil, openapi.ReportError("openapi error")
+			}
+		case error:
+			return "", openapi.ProblemDetailsSystemFailure(apiErr.Error()), nil
+		default:
+			return "", nil, openapi.ReportError("server no response")
+		}
+	}
+
+	logger.ConsumerLog.Debugf("GetSupiFromGpsi RspData: %+v", rsp.Udm_SDM_IdTranslationResult)
+	if rsp.Udm_SDM_IdTranslationResult.Supi == "" {
+		return "", openapi.ProblemDetailsDataNotFound("No SUPI found for the given GPSI"), nil
+	}
+	return rsp.Udm_SDM_IdTranslationResult.Supi, nil, nil
+}

--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -59,7 +59,7 @@ func (p *Processor) SmfNotification(
 		return
 	}
 
-	if err := postSmfEventExposureNotificationToAf(notifDestination, eeNotif, afCallbackTokenCtx); err != nil {
+	if err := postNotificationToAf(notifDestination, eeNotif, afCallbackTokenCtx); err != nil {
 		logger.TrafInfluLog.Errorf("Forward SMF notification to AF failed: %v", err)
 		pd := openapi.ProblemDetailsSystemFailure(err.Error())
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
@@ -70,14 +70,143 @@ func (p *Processor) SmfNotification(
 	c.Status(http.StatusNoContent)
 }
 
-func postSmfEventExposureNotificationToAf(
+// AmfEventNotification handles a Namf_EventExposure notification and forwards it, translated
+// into the AF-facing NefMonitoringNotification shape, to the AF's notificationDestination.
+func (p *Processor) AmfEventNotification(
+	c *gin.Context,
+	notif *models.Amf_EvtExpos_AmfEventNotification,
+) {
+	logger.SBILog.Infof("AmfEventNotification - NotifyCorrelationId[%s]", notif.NotifyCorrelationId)
+
+	af, monSub := p.Context().FindAfMonSub(notif.NotifyCorrelationId)
+	if monSub == nil {
+		pd := openapi.ProblemDetailsDataNotFound("Subscription is not found")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(http.StatusNotFound, pd)
+		return
+	}
+
+	af.Mu.RLock()
+	notifDestination := ""
+	var monSubCopy models.NefMonitoringEventSubscription
+	if monSub.MonSub != nil {
+		notifDestination = monSub.MonSub.NotificationDestination
+		monSubCopy = *monSub.MonSub
+	}
+	af.Mu.RUnlock()
+
+	if notifDestination == "" {
+		pd := openapi.ProblemDetailsSystemFailure("AF notification destination is empty")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(http.StatusInternalServerError, pd)
+		return
+	}
+
+	reports := make([]models.NefMonitoringEventReport, 0, len(notif.ReportList))
+	for _, r := range notif.ReportList {
+		reports = append(reports, models.NefMonitoringEventReport{
+			ExternalId:     monSubCopy.ExternalId,
+			Msisdn:         monSubCopy.Msisdn,
+			MonitoringType: monSubCopy.MonitoringType,
+			EventTime:      r.TimeStamp,
+			LocationInfo:   toLocationInfo(r.Location),
+			// LossOfConnectReason intentionally left unset: AMF's internal
+			// LossOfConnectivityReason has no defined mapping onto the TS 29.336 cause
+			// codes this field expects.
+		})
+	}
+	monNotif := &models.NefMonitoringNotification{
+		Subscription:           monSubCopy.Self,
+		MonitoringEventReports: reports,
+	}
+
+	afCallbackTokenCtx, pd, err := p.Context().GetTokenCtx(
+		models.Nrf_NFMgmt_ServiceName("nnef-callback"), models.Nrf_NFMgmt_NFType_AF)
+	if err != nil {
+		logger.SBILog.Errorf("Get token for AF callback failed: %+v", pd)
+		failure := openapi.ProblemDetailsSystemFailure("get token for AF callback failed")
+		if pd != nil && pd.Cause != "" {
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		} else {
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, failure.Cause)
+		}
+		c.JSON(http.StatusBadGateway, failure)
+		return
+	}
+
+	if err := postNotificationToAf(notifDestination, monNotif, afCallbackTokenCtx); err != nil {
+		logger.SBILog.Errorf("Forward AMF event notification to AF failed: %v", err)
+		pd := openapi.ProblemDetailsSystemFailure(err.Error())
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(http.StatusBadGateway, pd)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// toLocationInfo converts AMF's internal (TS 29.571) UserLocation into the AF-facing
+// (TS 29.122) LocationInfo shape used by MonitoringEventReport. Only NR and E-UTRA
+// locations are mapped; the other UserLocation variants (N3GA/UTRA/GERA) are not yet
+// supported by AMF's LOCATION_REPORT event.
+func toLocationInfo(loc *models.UserLocation) *models.NefLocationInfo {
+	if loc == nil {
+		return nil
+	}
+
+	switch {
+	case loc.NrLocation != nil:
+		nr := loc.NrLocation
+		info := &models.NefLocationInfo{
+			AgeOfLocationInfo: nr.AgeOfLocationInformation,
+		}
+		if nr.Ncgi != nil {
+			info.CellId = nr.Ncgi.NrCellId
+			info.PlmnId = plmnIdString(nr.Ncgi.PlmnId)
+		}
+		if nr.Tai != nil {
+			info.TrackingAreaId = nr.Tai.Tac
+			if info.PlmnId == "" {
+				info.PlmnId = plmnIdString(nr.Tai.PlmnId)
+			}
+		}
+		return info
+	case loc.EutraLocation != nil:
+		eutra := loc.EutraLocation
+		info := &models.NefLocationInfo{
+			AgeOfLocationInfo: eutra.AgeOfLocationInformation,
+		}
+		if eutra.Ecgi != nil {
+			info.EnodeBId = eutra.Ecgi.EutraCellId
+			info.PlmnId = plmnIdString(eutra.Ecgi.PlmnId)
+		}
+		if eutra.Tai != nil {
+			info.TrackingAreaId = eutra.Tai.Tac
+			if info.PlmnId == "" {
+				info.PlmnId = plmnIdString(eutra.Tai.PlmnId)
+			}
+		}
+		return info
+	default:
+		return nil
+	}
+}
+
+func plmnIdString(id *models.PlmnId) string {
+	if id == nil {
+		return ""
+	}
+	return id.Mcc + "-" + id.Mnc
+}
+
+func postNotificationToAf(
 	notifDestination string,
-	eeNotif *models.Smf_EvtExpos_NsmfEventExposureNotification,
+	body interface{},
 	requestCtx context.Context,
 ) error {
-	_, reqBody, err := openapi.Serialize(eeNotif, "application/json")
+	contentType, reqBody, err := openapi.Serialize(body, "application/json")
 	if err != nil {
-		return fmt.Errorf("serialize SMF notification failed: %w", err)
+		return fmt.Errorf("serialize notification failed: %w", err)
 	}
 	if requestCtx == nil {
 		requestCtx = context.Background()
@@ -87,7 +216,7 @@ func postSmfEventExposureNotificationToAf(
 	if err != nil {
 		return fmt.Errorf("create AF callback request failed: %w", err)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Content-Type", contentType)
 	if err = bindOAuthTokenToRequest(httpReq, requestCtx); err != nil {
 		return fmt.Errorf("bind OAuth2 token for AF callback failed: %w", err)
 	}

--- a/internal/sbi/processor/callback_test.go
+++ b/internal/sbi/processor/callback_test.go
@@ -2,11 +2,13 @@ package processor
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/free5gc/openapi"
 	"github.com/free5gc/openapi/models"
@@ -57,7 +59,7 @@ func TestBindOAuthTokenToRequest(t *testing.T) {
 	})
 }
 
-func TestPostSmfEventExposureNotificationToAfWithToken(t *testing.T) {
+func TestPostNotificationToAfWithToken(t *testing.T) {
 	openapi.InterceptInnerHttp2Client(t, false)
 	originalClient := afCallbackHTTPClient
 	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
@@ -77,12 +79,12 @@ func TestPostSmfEventExposureNotificationToAfWithToken(t *testing.T) {
 	tokenCtx := context.WithValue(context.Background(), openapi.ContextOAuth2, tok)
 
 	eeNotif := &models.Smf_EvtExpos_NsmfEventExposureNotification{NotifId: "notif-1"}
-	if err := postSmfEventExposureNotificationToAf("http://af.example.com/notify", eeNotif, tokenCtx); err != nil {
+	if err := postNotificationToAf("http://af.example.com/notify", eeNotif, tokenCtx); err != nil {
 		t.Fatalf("post callback failed: %v", err)
 	}
 }
 
-func TestPostSmfEventExposureNotificationToAfNon2xx(t *testing.T) {
+func TestPostNotificationToAfNon2xx(t *testing.T) {
 	openapi.InterceptInnerHttp2Client(t, false)
 	originalClient := afCallbackHTTPClient
 	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
@@ -96,7 +98,7 @@ func TestPostSmfEventExposureNotificationToAfNon2xx(t *testing.T) {
 	})}
 
 	eeNotif := &models.Smf_EvtExpos_NsmfEventExposureNotification{NotifId: "notif-2"}
-	err := postSmfEventExposureNotificationToAf("http://af.example.com/notify", eeNotif, context.TODO())
+	err := postNotificationToAf("http://af.example.com/notify", eeNotif, context.TODO())
 	if err == nil {
 		t.Fatal("expected error when AF callback returns non-2xx")
 	}
@@ -226,6 +228,148 @@ func TestSmfNotification_AfReturnsError(t *testing.T) {
 	c, w := newGinContext()
 	notif := &models.Smf_EvtExpos_NsmfEventExposureNotification{NotifId: afSub.NotifCorreID}
 	nefApp.Processor().SmfNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+// TestAmfEventNotification_NotifyCorrelationIdNotFound verifies that AmfEventNotification
+// returns 404 when the NotifyCorrelationId has no matching monitoring subscription.
+func TestAmfEventNotification_NotifyCorrelationIdNotFound(t *testing.T) {
+	c, w := newGinContext()
+
+	notif := &models.Amf_EvtExpos_AmfEventNotification{NotifyCorrelationId: "unknown-corr-id"}
+	nefApp.Processor().AmfEventNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestAmfEventNotification_EmptyNotifDest verifies that AmfEventNotification returns
+// 500 when the matching subscription has an empty notificationDestination.
+func TestAmfEventNotification_EmptyNotifDest(t *testing.T) {
+	nefCtx := nefApp.Context()
+	af := nefCtx.NewAf("af-amf-callback-test-1")
+	af.Mu.Lock()
+	correID := nefCtx.NewCorreID()
+	monSub := &models.NefMonitoringEventSubscription{
+		NotificationDestination: "", // intentionally empty
+	}
+	monSubCtx := af.NewMonSub(correID, monSub)
+	af.MonSubs[monSubCtx.SubID] = monSubCtx
+	nefCtx.AddAf(af)
+	af.Mu.Unlock()
+	defer func() {
+		nefCtx.DeleteAf(af.AfID)
+		nefCtx.ResetCorreID()
+	}()
+
+	c, w := newGinContext()
+	notif := &models.Amf_EvtExpos_AmfEventNotification{NotifyCorrelationId: monSubCtx.NotifCorreID}
+	nefApp.Processor().AmfEventNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestAmfEventNotification_SuccessfulForward verifies that AmfEventNotification translates
+// AMF's report into the AF-facing NefMonitoringNotification shape and forwards it, returning
+// 204 when the AF responds successfully.
+func TestAmfEventNotification_SuccessfulForward(t *testing.T) {
+	originalClient := afCallbackHTTPClient
+	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
+
+	var afReceivedBody []byte
+	afCallbackHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var readErr error
+		afReceivedBody, readErr = io.ReadAll(req.Body)
+		require.NoError(t, readErr)
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	nefCtx := nefApp.Context()
+	af := nefCtx.NewAf("af-amf-callback-test-2")
+	af.Mu.Lock()
+	correID := nefCtx.NewCorreID()
+	monSub := &models.NefMonitoringEventSubscription{
+		Msisdn:                  "0900000001",
+		NotificationDestination: "http://af.example.com/notify",
+		MonitoringType:          models.MonitoringType_UE_REACHABILITY,
+		Self:                    "http://nef.example.com/3gpp-monitoring-event/v1/af-amf-callback-test-2/subscriptions/1",
+	}
+	monSubCtx := af.NewMonSub(correID, monSub)
+	af.MonSubs[monSubCtx.SubID] = monSubCtx
+	nefCtx.AddAf(af)
+	af.Mu.Unlock()
+	defer func() {
+		nefCtx.DeleteAf(af.AfID)
+		nefCtx.ResetCorreID()
+	}()
+
+	eventTime := time.Now().UTC()
+	notif := &models.Amf_EvtExpos_AmfEventNotification{
+		NotifyCorrelationId: monSubCtx.NotifCorreID,
+		ReportList: []models.Amf_EvtExpos_AmfEventReport{
+			{
+				Type:      models.Amf_EvtExpos_AmfEventType_REACHABILITY_REPORT,
+				TimeStamp: &eventTime,
+			},
+		},
+	}
+
+	c, w := newGinContext()
+	nefApp.Processor().AmfEventNotification(c, notif)
+	c.Writer.WriteHeaderNow()
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.NotEmpty(t, afReceivedBody, "AF mock should have received the notification body")
+
+	var forwarded models.NefMonitoringNotification
+	require.NoError(t, json.Unmarshal(afReceivedBody, &forwarded))
+	require.Equal(t, monSub.Self, forwarded.Subscription)
+	require.Len(t, forwarded.MonitoringEventReports, 1)
+	require.Equal(t, monSub.Msisdn, forwarded.MonitoringEventReports[0].Msisdn)
+	require.Equal(t, monSub.MonitoringType, forwarded.MonitoringEventReports[0].MonitoringType)
+}
+
+// TestAmfEventNotification_AfReturnsError verifies that AmfEventNotification returns
+// 502 (BadGateway) when the AF callback endpoint responds with a non-2xx status.
+func TestAmfEventNotification_AfReturnsError(t *testing.T) {
+	originalClient := afCallbackHTTPClient
+	t.Cleanup(func() { afCallbackHTTPClient = originalClient })
+
+	afCallbackHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"status":403,"title":"Forbidden"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	nefCtx := nefApp.Context()
+	af := nefCtx.NewAf("af-amf-callback-test-3")
+	af.Mu.Lock()
+	correID := nefCtx.NewCorreID()
+	monSub := &models.NefMonitoringEventSubscription{
+		NotificationDestination: "http://af.example.com/notify",
+		MonitoringType:          models.MonitoringType_UE_REACHABILITY,
+	}
+	monSubCtx := af.NewMonSub(correID, monSub)
+	af.MonSubs[monSubCtx.SubID] = monSubCtx
+	nefCtx.AddAf(af)
+	af.Mu.Unlock()
+	defer func() {
+		nefCtx.DeleteAf(af.AfID)
+		nefCtx.ResetCorreID()
+	}()
+
+	c, w := newGinContext()
+	notif := &models.Amf_EvtExpos_AmfEventNotification{NotifyCorrelationId: monSubCtx.NotifCorreID}
+	nefApp.Processor().AmfEventNotification(c, notif)
 	c.Writer.WriteHeaderNow()
 
 	require.Equal(t, http.StatusBadGateway, w.Code)

--- a/internal/sbi/processor/monitoring.go
+++ b/internal/sbi/processor/monitoring.go
@@ -1,0 +1,273 @@
+package processor
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/free5gc/nef/internal/logger"
+	"github.com/free5gc/nef/pkg/factory"
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/util/metrics/sbi"
+	"github.com/gin-gonic/gin"
+)
+
+// supportedMonitoringTypes are the monitoring types AMF's Namf_EventExposure already exposes.
+// Other 3GPP-defined MonitoringType values (e.g. COMMUNICATION_FAILURE, which needs UDM's
+// Nudm_EE) are not yet wired up.
+var supportedMonitoringTypes = map[models.MonitoringType]models.Amf_EvtExpos_AmfEventType{
+	models.MonitoringType_LOSS_OF_CONNECTIVITY: models.Amf_EvtExpos_AmfEventType_LOSS_OF_CONNECTIVITY,
+	models.MonitoringType_UE_REACHABILITY:      models.Amf_EvtExpos_AmfEventType_REACHABILITY_REPORT,
+	models.MonitoringType_LOCATION_REPORTING:   models.Amf_EvtExpos_AmfEventType_LOCATION_REPORT,
+}
+
+// GetMonitoringEventSubscriptions Read all monitoring event subscriptions for a given AF
+// 3GPP TS 29.122 (reused by TS 29.522 for 5GS) Release 17
+func (p *Processor) GetMonitoringEventSubscriptions(
+	c *gin.Context,
+	afID string,
+) {
+	logger.SBILog.Infof("GetMonitoringEventSubscriptions - afID[%s]", afID)
+
+	af := p.Context().GetAf(afID)
+	if af == nil {
+		pd := openapi.ProblemDetailsDataNotFound("AF is not found")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	}
+
+	af.Mu.RLock()
+	defer af.Mu.RUnlock()
+
+	monSubs := make([]models.NefMonitoringEventSubscription, 0, len(af.MonSubs))
+	for _, sub := range af.MonSubs {
+		monSubs = append(monSubs, *sub.MonSub)
+	}
+	c.JSON(http.StatusOK, &monSubs)
+}
+
+// PostMonitoringEventSubscription Create a new monitoring event subscription
+// 3GPP TS 29.122 (reused by TS 29.522 for 5GS) Release 17
+func (p *Processor) PostMonitoringEventSubscription(
+	c *gin.Context,
+	afID string,
+	monSub *models.NefMonitoringEventSubscription,
+) {
+	logger.SBILog.Infof("PostMonitoringEventSubscription - afID[%s]", afID)
+
+	amfEventType, problemDetails := validateMonitoringEventData(monSub)
+	if problemDetails != nil {
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.JSON(int(problemDetails.Status), problemDetails)
+		return
+	}
+
+	nefCtx := p.Context()
+	af := nefCtx.GetAf(afID)
+	if af == nil {
+		af = nefCtx.NewAf(afID)
+		if af == nil {
+			pd := openapi.ProblemDetailsSystemFailure("No resource can be allocated")
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+			c.JSON(int(pd.Status), pd)
+			return
+		}
+	}
+
+	af.Mu.Lock()
+	defer af.Mu.Unlock()
+
+	correID := nefCtx.NewCorreID()
+	monSubCtx := af.NewMonSub(correID, monSub)
+
+	// AMF's event-subscription lookup only matches by Supi, not Gpsi (it never resolves
+	// GPSI itself), so NEF must resolve the AF-facing GPSI to a SUPI first via Nudm_SDM.
+	gpsi := buildGpsi(monSub.ExternalId, monSub.Msisdn)
+	supi, pd, err := p.Consumer().GetSupiFromGpsi(gpsi)
+	switch {
+	case pd != nil:
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	case err != nil:
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Detail: "Query to UDM failed",
+		}
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.JSON(int(problemDetails.Status), problemDetails)
+		return
+	}
+
+	amfSubID, pd, err := p.Consumer().CreateEventSubscription(
+		supi, []models.Amf_EvtExpos_AmfEventType{amfEventType}, p.genAmfEventNotifyUri(), monSubCtx.NotifCorreID)
+	switch {
+	case pd != nil:
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	case err != nil:
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Detail: "Query to AMF failed",
+		}
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.JSON(int(problemDetails.Status), problemDetails)
+		return
+	}
+	monSubCtx.AmfSubID = amfSubID
+
+	af.MonSubs[monSubCtx.SubID] = monSubCtx
+	af.Log.Infoln("Monitoring event subscription is added")
+
+	nefCtx.AddAf(af)
+
+	monSub.Self = p.genMonitoringEventSubURI(afID, monSubCtx.SubID)
+	headers := map[string][]string{
+		"Location": {monSub.Self},
+	}
+	for hdrName, hdrValues := range headers {
+		for _, hdrValue := range hdrValues {
+			c.Header(hdrName, hdrValue)
+		}
+	}
+	c.JSON(http.StatusCreated, monSub)
+}
+
+// GetIndividualMonitoringEventSubscription Read an individual monitoring event subscription
+// 3GPP TS 29.122 (reused by TS 29.522 for 5GS) Release 17
+func (p *Processor) GetIndividualMonitoringEventSubscription(
+	c *gin.Context,
+	afID, subID string,
+) {
+	logger.SBILog.Infof("GetIndividualMonitoringEventSubscription - afID[%s], subID[%s]", afID, subID)
+
+	af := p.Context().GetAf(afID)
+	if af == nil {
+		pd := openapi.ProblemDetailsDataNotFound("AF is not found")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	}
+
+	af.Mu.RLock()
+	defer af.Mu.RUnlock()
+
+	monSubCtx, ok := af.MonSubs[subID]
+	if !ok {
+		pd := openapi.ProblemDetailsDataNotFound("Subscription is not found")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	}
+
+	c.JSON(http.StatusOK, monSubCtx.MonSub)
+}
+
+// DeleteIndividualMonitoringEventSubscription Delete an individual monitoring event subscription
+// 3GPP TS 29.122 (reused by TS 29.522 for 5GS) Release 17
+func (p *Processor) DeleteIndividualMonitoringEventSubscription(
+	c *gin.Context,
+	afID, subID string,
+) {
+	logger.SBILog.Infof("DeleteIndividualMonitoringEventSubscription - afID[%s], subID[%s]", afID, subID)
+
+	af := p.Context().GetAf(afID)
+	if af == nil {
+		pd := openapi.ProblemDetailsDataNotFound("AF is not found")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	}
+
+	af.Mu.Lock()
+	defer af.Mu.Unlock()
+
+	monSubCtx, ok := af.MonSubs[subID]
+	if !ok {
+		pd := openapi.ProblemDetailsDataNotFound("Subscription is not found")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	}
+
+	pd, err := p.Consumer().DeleteEventSubscription(monSubCtx.AmfSubID)
+	switch {
+	case pd != nil:
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	case err != nil:
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Detail: "Query to AMF failed",
+		}
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.JSON(int(problemDetails.Status), problemDetails)
+		return
+	}
+
+	delete(af.MonSubs, subID)
+	c.Status(http.StatusNoContent)
+}
+
+func validateMonitoringEventData(
+	monSub *models.NefMonitoringEventSubscription,
+) (models.Amf_EvtExpos_AmfEventType, *models.ProblemDetails) {
+	if monSub.NotificationDestination == "" {
+		return "", openapi.ProblemDetailsMalformedReqSyntax("Missing notificationDestination")
+	}
+
+	parsedNotificationDestination, err := url.ParseRequestURI(monSub.NotificationDestination)
+	if err != nil || parsedNotificationDestination.Scheme == "" || parsedNotificationDestination.Host == "" {
+		return "", openapi.ProblemDetailsMalformedReqSyntax("Invalid notificationDestination")
+	}
+
+	// TS29.122 allows identifying the target UE by externalId, msisdn, ipv4Addr or ipv6Addr.
+	// v1 only supports externalId/msisdn: AMF's Namf_EventExposure subscription is keyed by
+	// Gpsi (extid-/msisdn- prefixed), which has no IP-address form, so an IP-only request
+	// cannot be forwarded to AMF.
+	if monSub.ExternalId == "" && monSub.Msisdn == "" {
+		if monSub.Ipv4Addr != "" || monSub.Ipv6Addr != "" {
+			return "", openapi.
+				ProblemDetailsMalformedReqSyntax(
+					"Ipv4Addr/Ipv6Addr-only target identification is not yet supported; provide ExternalId or Msisdn")
+		}
+		return "", openapi.ProblemDetailsMalformedReqSyntax("Missing one of ExternalId, Msisdn")
+	}
+
+	amfEventType, ok := supportedMonitoringTypes[monSub.MonitoringType]
+	if !ok {
+		return "", openapi.
+			ProblemDetailsMalformedReqSyntax("Unsupported or missing monitoringType")
+	}
+
+	// TS29.122: at least one of maximumNumberOfReports or monitorExpireTime shall be present.
+	if monSub.MaximumNumberOfReports == 0 && monSub.MonitorExpireTime == nil {
+		return "", openapi.
+			ProblemDetailsMalformedReqSyntax("Missing one of MaximumNumberOfReports, MonitorExpireTime")
+	}
+
+	return amfEventType, nil
+}
+
+// buildGpsi formats an AF-facing target UE identifier as the GPSI string AMF expects
+// (3GPP TS 23.003 clause 19.7.2 / clause 4.9.4 for external ID and MSISDN respectively).
+func buildGpsi(externalId, msisdn string) string {
+	if externalId != "" {
+		return "extid-" + externalId
+	}
+	return "msisdn-" + msisdn
+}
+
+func (p *Processor) genMonitoringEventSubURI(
+	afID, subscriptionId string,
+) string {
+	// E.g. https://localhost:29505/3gpp-monitoring-event/v1/{afId}/subscriptions/{subscriptionId}
+	return p.Config().ServiceUri(factory.ServiceNefMonitoringEvent) + "/" + afID + "/subscriptions/" + subscriptionId
+}
+
+func (p *Processor) genAmfEventNotifyUri() string {
+	return p.Config().ServiceUri(factory.ServiceNefCallback) + "/notification/amf-event"
+}

--- a/internal/sbi/processor/monitoring_test.go
+++ b/internal/sbi/processor/monitoring_test.go
@@ -1,0 +1,504 @@
+package processor
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/free5gc/openapi/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var (
+	monSub1ForAf1 = models.NefMonitoringEventSubscription{
+		ExternalId:              "10001@domain.com",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/monitoring-event/app1",
+		MonitoringType:          models.MonitoringType_UE_REACHABILITY,
+		MaximumNumberOfReports:  1,
+	}
+
+	monSub2ForAf1 = models.NefMonitoringEventSubscription{
+		ExternalId:             "10002@domain.com",
+		MonitoringType:         models.MonitoringType_UE_REACHABILITY,
+		MaximumNumberOfReports: 1,
+		// NotificationDestination intentionally missing
+	}
+
+	monSub3ForAf1 = models.NefMonitoringEventSubscription{
+		ExternalId:              "10003@domain.com",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/monitoring-event/app3",
+		MonitoringType:          models.MonitoringType_ROAMING_STATUS, // not yet supported
+		MaximumNumberOfReports:  1,
+	}
+
+	monSub4ForAf1 = models.NefMonitoringEventSubscription{
+		Ipv4Addr:                "10.60.0.10", // no ExternalId/Msisdn
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/monitoring-event/app4",
+		MonitoringType:          models.MonitoringType_LOCATION_REPORTING,
+		MaximumNumberOfReports:  1,
+	}
+
+	monSub5ForAf1 = models.NefMonitoringEventSubscription{
+		ExternalId:              "10005@domain.com",
+		NotificationDestination: "http://127.0.0.100:8000/nnef-callback/v1/monitoring-event/app5",
+		MonitoringType:          models.MonitoringType_LOSS_OF_CONNECTIVITY,
+		// MaximumNumberOfReports and MonitorExpireTime both missing
+	}
+)
+
+func TestGetMonitoringEventSubscriptions(t *testing.T) {
+	testCases := []struct {
+		description      string
+		afID             string
+		expectedResponse *HandlerResponse
+	}{
+		{
+			description: "TC1: AfID found, should return all monitoring event subscriptions",
+			afID:        "af1",
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusOK,
+				Body:   &[]models.NefMonitoringEventSubscription{monSub1ForAf1},
+			},
+		},
+		{
+			description: "TC2: AfID not found, should return ProblemDetails",
+			afID:        "af3",
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusNotFound,
+				Body: &models.ProblemDetails{
+					Status: http.StatusNotFound,
+					Title:  "Data not found",
+					Detail: "AF is not found",
+				},
+			},
+		},
+	}
+
+	nefCtx := nefApp.Context()
+	af1 := nefCtx.NewAf("af1")
+	af1.Mu.Lock()
+	correID1 := nefCtx.NewCorreID()
+	monSubCtx1 := af1.NewMonSub(correID1, &monSub1ForAf1)
+	af1.MonSubs[monSubCtx1.SubID] = monSubCtx1
+	nefCtx.AddAf(af1)
+	af1.Mu.Unlock()
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			httpRecorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(httpRecorder)
+
+			nefApp.Processor().GetMonitoringEventSubscriptions(c, tc.afID)
+			require.Equal(t, tc.expectedResponse.Status, httpRecorder.Code)
+
+			if monSubs, ok := tc.expectedResponse.Body.(*[]models.NefMonitoringEventSubscription); ok {
+				var rspSubs []models.NefMonitoringEventSubscription
+				require.NoError(t, json.Unmarshal(httpRecorder.Body.Bytes(), &rspSubs))
+				require.ElementsMatch(t, *monSubs, rspSubs)
+			} else {
+				assertJSONBodyEqual(t, tc.expectedResponse.Body, httpRecorder.Body.Bytes())
+			}
+		})
+	}
+
+	nefCtx.DeleteAf(af1.AfID)
+	nefCtx.ResetCorreID()
+}
+
+func TestGetIndividualMonitoringEventSubscription(t *testing.T) {
+	testCases := []struct {
+		description      string
+		afID             string
+		subID            string
+		expectedResponse *HandlerResponse
+	}{
+		{
+			description: "TC1: AfID & SubID found, should return the subscription",
+			afID:        "af1",
+			subID:       "1",
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusOK,
+				Body:   &monSub1ForAf1,
+			},
+		},
+		{
+			description: "TC2: AfID found but SubID not found, should return ProblemDetails",
+			afID:        "af1",
+			subID:       "2",
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusNotFound,
+				Body: &models.ProblemDetails{
+					Status: http.StatusNotFound,
+					Title:  "Data not found",
+					Detail: "Subscription is not found",
+				},
+			},
+		},
+		{
+			description: "TC3: AfID not found, should return ProblemDetails",
+			afID:        "af3",
+			subID:       "1",
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusNotFound,
+				Body: &models.ProblemDetails{
+					Status: http.StatusNotFound,
+					Title:  "Data not found",
+					Detail: "AF is not found",
+				},
+			},
+		},
+	}
+
+	nefCtx := nefApp.Context()
+	af1 := nefCtx.NewAf("af1")
+	af1.Mu.Lock()
+	correID1 := nefCtx.NewCorreID()
+	monSubCtx1 := af1.NewMonSub(correID1, &monSub1ForAf1)
+	af1.MonSubs[monSubCtx1.SubID] = monSubCtx1
+	nefCtx.AddAf(af1)
+	af1.Mu.Unlock()
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			httpRecorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(httpRecorder)
+
+			nefApp.Processor().GetIndividualMonitoringEventSubscription(c, tc.afID, tc.subID)
+			require.Equal(t, tc.expectedResponse.Status, httpRecorder.Code)
+
+			assertJSONBodyEqual(t, tc.expectedResponse.Body, httpRecorder.Body.Bytes())
+		})
+	}
+
+	nefCtx.DeleteAf(af1.AfID)
+	nefCtx.ResetCorreID()
+}
+
+func TestPostMonitoringEventSubscription(t *testing.T) {
+	// Mocks below are intentionally not gock.Off()'d: Off() flushes gock's global mock
+	// registry, including the one-shot NRF discovery mocks other test files register once
+	// in TestMain, breaking them for whichever test runs later. Each mock here is scoped
+	// to a single expected call and self-disables after matching, so no cleanup is needed.
+	initNRFDiscUDMSdmStub()
+	initUDMSdmGetSupiOrGpsiStub(http.StatusOK, "imsi-208930000000001")
+	initNRFDiscAMFStub()
+	initAMFEvtsCreateSubscriptionStub(http.StatusCreated, "amf-sub-1")
+
+	rspMonSub1 := monSub1ForAf1
+	rspMonSub1.Self = nefApp.Processor().genMonitoringEventSubURI("af1", "1")
+
+	testCases := []struct {
+		description      string
+		afID             string
+		monSub           *models.NefMonitoringEventSubscription
+		expectedResponse *HandlerResponse
+	}{
+		{
+			description: "TC1: Successful UE_REACHABILITY subscription, should create a Namf_EventExposure subscription",
+			afID:        "af1",
+			monSub:      &monSub1ForAf1,
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusCreated,
+				Headers: map[string][]string{
+					"Location": {rspMonSub1.Self},
+				},
+				Body: &rspMonSub1,
+			},
+		},
+		{
+			description: "TC2: Missing notificationDestination",
+			afID:        "af1",
+			monSub:      &monSub2ForAf1,
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusBadRequest,
+				Body: &models.ProblemDetails{
+					Status: http.StatusBadRequest,
+					Title:  "Malformed request syntax",
+					Detail: "Missing notificationDestination",
+				},
+			},
+		},
+		{
+			description: "TC3: Unsupported monitoringType",
+			afID:        "af1",
+			monSub:      &monSub3ForAf1,
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusBadRequest,
+				Body: &models.ProblemDetails{
+					Status: http.StatusBadRequest,
+					Title:  "Malformed request syntax",
+					Detail: "Unsupported or missing monitoringType",
+				},
+			},
+		},
+		{
+			description: "TC4: Ipv4Addr-only target identification is not yet supported",
+			afID:        "af1",
+			monSub:      &monSub4ForAf1,
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusBadRequest,
+				Body: &models.ProblemDetails{
+					Status: http.StatusBadRequest,
+					Title:  "Malformed request syntax",
+					Detail: "Ipv4Addr/Ipv6Addr-only target identification is not yet supported; provide ExternalId or Msisdn",
+				},
+			},
+		},
+		{
+			description: "TC5: Missing one of MaximumNumberOfReports, MonitorExpireTime",
+			afID:        "af1",
+			monSub:      &monSub5ForAf1,
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusBadRequest,
+				Body: &models.ProblemDetails{
+					Status: http.StatusBadRequest,
+					Title:  "Malformed request syntax",
+					Detail: "Missing one of MaximumNumberOfReports, MonitorExpireTime",
+				},
+			},
+		},
+	}
+
+	nefCtx := nefApp.Context()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			httpRecorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(httpRecorder)
+
+			nefApp.Processor().PostMonitoringEventSubscription(c, tc.afID, tc.monSub)
+			require.Equal(t, tc.expectedResponse.Status, httpRecorder.Code)
+
+			if tc.expectedResponse.Headers != nil {
+				for k, v := range tc.expectedResponse.Headers {
+					resp := httpRecorder.Result()
+					defer func() {
+						if err := resp.Body.Close(); err != nil {
+							t.Errorf("failed to close resp body: %v", err)
+						}
+					}()
+
+					require.ElementsMatch(t, v, resp.Header.Values(k))
+				}
+			}
+
+			assertJSONBodyEqual(t, tc.expectedResponse.Body, httpRecorder.Body.Bytes())
+		})
+	}
+	nefCtx.DeleteAf("af1")
+	nefCtx.ResetCorreID()
+}
+
+// TestPostMonitoringEventSubscription_AmfError verifies that an AMF-side failure is
+// surfaced to the AF as the ProblemDetails AMF returned, rather than a generic error.
+func TestPostMonitoringEventSubscription_AmfError(t *testing.T) {
+	initNRFDiscUDMSdmStub()
+	initUDMSdmGetSupiOrGpsiStub(http.StatusOK, "imsi-208930000000001")
+	initNRFDiscAMFStub()
+	initAMFEvtsCreateSubscriptionErrorStub(http.StatusForbidden)
+
+	monSub := monSub1ForAf1
+
+	httpRecorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(httpRecorder)
+
+	nefApp.Processor().PostMonitoringEventSubscription(c, "af1", &monSub)
+	require.Equal(t, http.StatusForbidden, httpRecorder.Code)
+
+	nefApp.Context().DeleteAf("af1")
+	nefApp.Context().ResetCorreID()
+}
+
+func TestDeleteIndividualMonitoringEventSubscription(t *testing.T) {
+	initNRFDiscAMFStub()
+	initAMFEvtsDeleteSubscriptionStub(http.StatusNoContent)
+
+	testCases := []struct {
+		description      string
+		afID             string
+		subID            string
+		expectedResponse *HandlerResponse
+	}{
+		{
+			description: "TC1: Successful delete monitoring event subscription",
+			afID:        "af1",
+			subID:       "1",
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusNoContent,
+			},
+		},
+		{
+			description: "TC2: Delete non-existent monitoring event subscription",
+			afID:        "af1",
+			subID:       "2",
+			expectedResponse: &HandlerResponse{
+				Status: http.StatusNotFound,
+				Body: &models.ProblemDetails{
+					Status: http.StatusNotFound,
+					Title:  "Data not found",
+					Detail: "Subscription is not found",
+				},
+			},
+		},
+	}
+
+	nefCtx := nefApp.Context()
+	af1 := nefCtx.NewAf("af1")
+	af1.Mu.Lock()
+	correID1 := nefCtx.NewCorreID()
+	monSubCtx1 := af1.NewMonSub(correID1, &monSub1ForAf1)
+	monSubCtx1.AmfSubID = "amf-sub-1"
+	af1.MonSubs[monSubCtx1.SubID] = monSubCtx1
+	nefCtx.AddAf(af1)
+	af1.Mu.Unlock()
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			httpRecorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(httpRecorder)
+
+			nefApp.Processor().DeleteIndividualMonitoringEventSubscription(c, tc.afID, tc.subID)
+			c.Writer.WriteHeaderNow()
+			require.Equal(t, tc.expectedResponse.Status, httpRecorder.Code)
+
+			assertJSONBodyEqual(t, tc.expectedResponse.Body, httpRecorder.Body.Bytes())
+		})
+	}
+	nefCtx.DeleteAf(af1.AfID)
+	nefCtx.ResetCorreID()
+}
+
+func initNRFDiscAMFStub() {
+	searchResult := &models.Nrf_NFDisc_SearchResult{
+		ValidityPeriod: 100,
+		NfInstances: []models.Nrf_NFDisc_NFProfile{
+			{
+				NfInstanceId: "nef-unit-testing",
+				NfType:       "AMF",
+				NfStatus:     "REGISTERED",
+				Ipv4Addresses: []string{
+					"127.0.0.18",
+				},
+				NfServices: []models.Nrf_NFDisc_NFService{
+					{
+						ServiceInstanceId: "1",
+						ServiceName:       "namf-evts",
+						Versions: []models.Nrf_NFMgmt_NFServiceVersion{
+							{
+								ApiVersionInUri: "v1",
+								ApiFullVersion:  "1.0.0",
+							},
+						},
+						Scheme:          "http",
+						NfServiceStatus: "REGISTERED",
+						IpEndPoints: []models.Nrf_NFMgmt_IpEndPoint{
+							{
+								Ipv4Address: "127.0.0.18",
+								Transport:   "TCP",
+								Port:        8000,
+							},
+						},
+						ApiPrefix: "http://127.0.0.18:8000",
+					},
+				},
+			},
+		},
+	}
+
+	gock.New("http://127.0.0.10:8000/nnrf-disc/v1").
+		Get("/nf-instances").
+		MatchParam("target-nf-type", "AMF").
+		MatchParam("requester-nf-type", "NEF").
+		MatchParam("service-names", "namf-evts").
+		Reply(http.StatusOK).
+		JSON(searchResult)
+}
+
+// initAMFEvtsCreateSubscriptionStub matches exactly one POST, matching the single
+// successful create in TestPostMonitoringEventSubscription's TC1; gock auto-disables it
+// after that match, so it can't bleed into any other test.
+func initAMFEvtsCreateSubscriptionStub(statusCode int, amfSubID string) {
+	rsp := models.Amf_EvtExpos_AmfCreatedEventSubscription{
+		SubscriptionId: amfSubID,
+	}
+	gock.New("http://127.0.0.18:8000/namf-evts/v1").
+		Post("/subscriptions").
+		Reply(statusCode).
+		JSON(rsp)
+}
+
+func initAMFEvtsCreateSubscriptionErrorStub(statusCode int) {
+	pd := models.ProblemDetails{
+		Status: int32(statusCode),
+		Title:  "Forbidden",
+		Detail: "subscription rejected by AMF",
+	}
+	gock.New("http://127.0.0.18:8000/namf-evts/v1").
+		Post("/subscriptions").
+		Reply(statusCode).
+		JSON(pd)
+}
+
+func initAMFEvtsDeleteSubscriptionStub(statusCode int) {
+	gock.New("http://127.0.0.18:8000/namf-evts/v1").
+		Delete("/subscriptions/.*").
+		Reply(statusCode)
+}
+
+func initNRFDiscUDMSdmStub() {
+	searchResult := &models.Nrf_NFDisc_SearchResult{
+		ValidityPeriod: 100,
+		NfInstances: []models.Nrf_NFDisc_NFProfile{
+			{
+				NfInstanceId: "nef-unit-testing",
+				NfType:       "UDM",
+				NfStatus:     "REGISTERED",
+				Ipv4Addresses: []string{
+					"127.0.0.3",
+				},
+				NfServices: []models.Nrf_NFDisc_NFService{
+					{
+						ServiceInstanceId: "1",
+						ServiceName:       "nudm-sdm",
+						Versions: []models.Nrf_NFMgmt_NFServiceVersion{
+							{
+								ApiVersionInUri: "v2",
+								ApiFullVersion:  "1.0.0",
+							},
+						},
+						Scheme:          "http",
+						NfServiceStatus: "REGISTERED",
+						IpEndPoints: []models.Nrf_NFMgmt_IpEndPoint{
+							{
+								Ipv4Address: "127.0.0.3",
+								Transport:   "TCP",
+								Port:        8000,
+							},
+						},
+						ApiPrefix: "http://127.0.0.3:8000",
+					},
+				},
+			},
+		},
+	}
+
+	gock.New("http://127.0.0.10:8000/nnrf-disc/v1").
+		Get("/nf-instances").
+		MatchParam("target-nf-type", "UDM").
+		MatchParam("requester-nf-type", "NEF").
+		MatchParam("service-names", "nudm-sdm").
+		Reply(http.StatusOK).
+		JSON(searchResult)
+}
+
+func initUDMSdmGetSupiOrGpsiStub(statusCode int, supi string) {
+	rsp := models.Udm_SDM_IdTranslationResult{
+		Supi: supi,
+	}
+	gock.New("http://127.0.0.3:8000/nudm-sdm/v2").
+		Get("/.*/id-translation-result").
+		Reply(statusCode).
+		JSON(rsp)
+}

--- a/internal/sbi/server.go
+++ b/internal/sbi/server.go
@@ -94,6 +94,16 @@ func NewServer(nef nef, tlsKeyLogPath string) (*Server, error) {
 				authCheck.Check(c, s.Context())
 			})
 			applyRoutes(tiGroup, s.getTrafficInfluenceRoutes())
+
+		case factory.ServiceNefMonitoringEvent:
+			// 3gpp-monitoring-event is an AF-facing API (3GPP TS 29.122, reused by TS 29.522
+			// for 5GS);
+			authCheck := nef_util.NewRouterAuthorizationCheck(models.Nrf_NFMgmt_ServiceName_3GPP_MONITORING_EVENT)
+			monGroup := s.router.Group(factory.MonitoringEventResUriPrefix)
+			monGroup.Use(func(c *gin.Context) {
+				authCheck.Check(c, s.Context())
+			})
+			applyRoutes(monGroup, s.getMonitoringEventRoutes())
 		}
 	}
 

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -20,11 +20,12 @@ import (
 )
 
 const (
-	ServiceTraffInflu  string = "3gpp-traffic-influence"
-	ServicePfdMng      string = "3gpp-pfd-management"
-	ServiceNefPfd      string = string(models.Nrf_NFMgmt_ServiceName_NNEF_PFDMANAGEMENT)
-	ServiceNefOam      string = "nnef-oam"
-	ServiceNefCallback string = "nnef-callback"
+	ServiceTraffInflu         string = "3gpp-traffic-influence"
+	ServicePfdMng             string = "3gpp-pfd-management"
+	ServiceNefPfd             string = string(models.Nrf_NFMgmt_ServiceName_NNEF_PFDMANAGEMENT)
+	ServiceNefOam             string = "nnef-oam"
+	ServiceNefCallback        string = "nnef-callback"
+	ServiceNefMonitoringEvent string = string(models.Nrf_NFMgmt_ServiceName_3GPP_MONITORING_EVENT)
 )
 
 const (
@@ -47,6 +48,7 @@ const (
 	NefPfdMngResUriPrefix        = "/" + ServiceNefPfd + "/v1"
 	NefOamResUriPrefix           = "/" + ServiceNefOam + "/v1"
 	NefCallbackResUriPrefix      = "/" + ServiceNefCallback + "/v1"
+	MonitoringEventResUriPrefix  = "/" + ServiceNefMonitoringEvent + "/v1"
 )
 
 type Config struct {
@@ -129,11 +131,13 @@ func (c *Configuration) validate() (bool, error) {
 		case ServiceNefOam:
 		case ServiceTraffInflu:
 		case ServiceNefCallback:
+		case ServiceNefMonitoringEvent:
 		default:
 			err := errors.New(
 				"invalid serviceList[" + strconv.Itoa(i) + "]: " +
 					s.ServiceName + ", should be " + ServiceNefPfd + ", " +
-					ServiceNefOam + ", " + ServiceTraffInflu + ", or " + ServiceNefCallback,
+					ServiceNefOam + ", " + ServiceTraffInflu + ", " + ServiceNefCallback +
+					", or " + ServiceNefMonitoringEvent,
 			)
 			return false, appendInvalid(err)
 		}
@@ -575,6 +579,8 @@ func (c *Config) ServiceUri(name string) string {
 		return c.SbiUri() + NefOamResUriPrefix
 	case ServiceNefCallback:
 		return c.SbiUri() + NefCallbackResUriPrefix
+	case ServiceNefMonitoringEvent:
+		return c.SbiUri() + MonitoringEventResUriPrefix
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

Adds NEF's AF-facing **Monitoring Event API** (3GPP TS 29.122, reused by TS 29.522 for 5GS). See [issue #1143](https://github.com/free5gc/free5gc/issues/1143) for the original proposal and scope discussion.

NEF currently implements PFD Management and Traffic Influence but not Monitoring Event, even though the service name constant (`ServiceName_3GPP_MONITORING_EVENT`) was already reserved in `free5gc/openapi`. AMF's `Namf_EventExposure` already implements the backend this needs.

### Scope (v1)

- **Event types:** `LOSS_OF_CONNECTIVITY`, `UE_REACHABILITY`, `LOCATION_REPORTING` — the three that map onto event types AMF already exposes. Other `MonitoringType` values are rejected with 400 until follow-up work adds UDM `Nudm_EE` integration for the rest (`COMMUNICATION_FAILURE`, etc.).
- **Operations:** `POST`/`GET`/`DELETE`. `PUT`/`PATCH` are left as follow-up work — delete+recreate covers modification for now.
- **Consumer:** NEF talks to AMF and UDM.

### A note on GPSI vs SUPI

AMF's `AmfEventSubscription` model has a `Gpsi` field, but I found (by reading `CreateAMFEventSubscriptionProcedure`, not just the OpenAPI schema) that free5gc's actual AMF implementation only ever looks up the target UE by `Supi` — it never resolves `Gpsi`. So NEF resolves the AF-supplied `externalId`/`msisdn` to a SUPI itself via `Nudm_SDM`'s GPSI-to-SUPI translation (TS 29.503 clause 5.2.2.7.1, already implemented in `free5gc/udm` as `GetIdTranslationResult`) before calling AMF.

### Notification callback

Added a callback route (`/nnef-callback/v1/notification/amf-event`) to receive AMF's event report and forward it, translated into the AF-facing `NefMonitoringNotification` shape, to the AF's `notificationDestination`. Refactored the existing SMF notification forwarder (`postSmfEventExposureNotificationToAf`) into a shared `postNotificationToAf` helper used by both, rather than duplicating the delivery logic.

Note: I could not find any code path in `free5gc/amf` that actually sends this notification asynchronously (only a synchronous "immediate report in the create response" exists) — confirmed this is a known gap, already tracked as [free5gc/amf#78](https://github.com/free5gc/amf/issues/78). So this side is covered by mocked unit tests rather than a live end-to-end trigger.

### Verification

- Verified against a real running free5gc deployment (NRF/AMF/UDM/UDR/PCF/AUSF/NSSF/UPF, with a UE registered via UERANSIM against seeded subscriber data) - a real `POST` creates a real `Namf_EventExposure` subscription and returns `201`, `GET` returns it, `DELETE` returns `204`. Not just mocked.
- `go build`/`go vet`/`go test ./...` pass; `golangci-lint` (matching this repo's config) reports 0 issues.

### Dependency on free5gc/openapi#82

This needs the new models added in [free5gc/openapi#82](https://github.com/free5gc/openapi/pull/82) (`NefMonitoringEventSubscription`, `NefMonitoringEventReport`, `NefLocationInfo`, etc.). `go.mod` currently has a `replace` pointing at that PR's branch so this builds and passes CI in the meantime - **this replace directive needs to be removed and the `require` bumped to a real release once that PR merges.** Happy to update this PR once that lands, or if you'd prefer these merged in the other order.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages, including new `monitoring_test.go` and the added `AmfEventNotification` callback tests)
- [x] `golangci-lint run ./...` - 0 issues
- [x] Manual end-to-end test against a real deployment (NRF/AMF/UDM/UDR/UPF + UERANSIM UE): `POST`/`GET`/`DELETE` all verified with real 201/200/204 responses